### PR TITLE
MAINT: Mark data section non-executable

### DIFF
--- a/linux/avx512/svml_z0_acos_d_la.s
+++ b/linux/avx512/svml_z0_acos_d_la.s
@@ -2640,3 +2640,5 @@ _vmldACosHATab:
 	.long	0x00000000,0x80000000,0x00000000,0x00000000
 	.type	.L_2il0floatpacket.197,@object
 	.size	.L_2il0floatpacket.197,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_acos_s_la.s
+++ b/linux/avx512/svml_z0_acos_s_la.s
@@ -2290,3 +2290,5 @@ _vmldACosHATab:
 	.long	0x00000000,0x80000000,0x00000000,0x00000000
 	.type	.L_2il0floatpacket.199,@object
 	.size	.L_2il0floatpacket.199,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_acosh_d_la.s
+++ b/linux/avx512/svml_z0_acosh_d_la.s
@@ -889,3 +889,5 @@ __dacosh_la_CoutTab:
 	.long	4293918720
 	.type	__dacosh_la_CoutTab,@object
 	.size	__dacosh_la_CoutTab,32
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_acosh_s_la.s
+++ b/linux/avx512/svml_z0_acosh_s_la.s
@@ -683,3 +683,5 @@ __sacosh_la__iml_sacosh_cout_tab:
 	.long	2139095040
 	.type	__sacosh_la__iml_sacosh_cout_tab,@object
 	.size	__sacosh_la__iml_sacosh_cout_tab,12
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_asin_d_la.s
+++ b/linux/avx512/svml_z0_asin_d_la.s
@@ -2549,3 +2549,5 @@ _vmldASinHATab:
 	.long	3217739776
 	.type	_vmldASinHATab,@object
 	.size	_vmldASinHATab,4504
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_asin_s_la.s
+++ b/linux/avx512/svml_z0_asin_s_la.s
@@ -2197,3 +2197,5 @@ _vmldASinHATab:
 	.long	3217739776
 	.type	_vmldASinHATab,@object
 	.size	_vmldASinHATab,4504
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_asinh_d_la.s
+++ b/linux/avx512/svml_z0_asinh_d_la.s
@@ -872,3 +872,5 @@ __svml_dasinh_data_internal_avx512:
 	.long	1031600026
 	.type	__svml_dasinh_data_internal_avx512,@object
 	.size	__svml_dasinh_data_internal_avx512,2048
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_asinh_s_la.s
+++ b/linux/avx512/svml_z0_asinh_s_la.s
@@ -671,3 +671,5 @@ __svml_sasinh_data_internal_avx512:
 	.long	939916788
 	.type	__svml_sasinh_data_internal_avx512,@object
 	.size	__svml_sasinh_data_internal_avx512,1344
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan2_d_la.s
+++ b/linux/avx512/svml_z0_atan2_d_la.s
@@ -2391,3 +2391,5 @@ __datan2_la_CoutTab:
 	.long	0xffffffff,0xffffffff
 	.type	.L_2il0floatpacket.31,@object
 	.size	.L_2il0floatpacket.31,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan2_s_la.s
+++ b/linux/avx512/svml_z0_atan2_s_la.s
@@ -2072,3 +2072,5 @@ __satan2_la_CoutTab:
 	.long	1101004800
 	.type	__satan2_la_CoutTab,@object
 	.size	__satan2_la_CoutTab,2008
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan_d_la.s
+++ b/linux/avx512/svml_z0_atan_d_la.s
@@ -1350,3 +1350,5 @@ __datan_la_CoutTab:
 	.long	0x00000000,0x3ff00000
 	.type	.L_2il0floatpacket.14,@object
 	.size	.L_2il0floatpacket.14,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan_s_la.s
+++ b/linux/avx512/svml_z0_atan_s_la.s
@@ -353,3 +353,5 @@ __svml_satan_data_internal_avx512:
 	.long	3198855850
 	.type	__svml_satan_data_internal_avx512,@object
 	.size	__svml_satan_data_internal_avx512,1024
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atanh_d_la.s
+++ b/linux/avx512/svml_z0_atanh_d_la.s
@@ -654,3 +654,5 @@ __datanh_la_CoutTab:
 	.long	4293918720
 	.type	__datanh_la_CoutTab,@object
 	.size	__datanh_la_CoutTab,32
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atanh_s_la.s
+++ b/linux/avx512/svml_z0_atanh_s_la.s
@@ -556,3 +556,5 @@ __satanh_la__imlsAtanhTab:
 	.long	2139095040
 	.type	__satanh_la__imlsAtanhTab,@object
 	.size	__satanh_la__imlsAtanhTab,12
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cbrt_d_la.s
+++ b/linux/avx512/svml_z0_cbrt_d_la.s
@@ -909,3 +909,5 @@ __dcbrt_la__vmldCbrtTab:
 	.long	0x00000000,0x80000000,0x00000000,0x00000000
 	.type	.L_2il0floatpacket.81,@object
 	.size	.L_2il0floatpacket.81,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cbrt_s_la.s
+++ b/linux/avx512/svml_z0_cbrt_s_la.s
@@ -1010,3 +1010,5 @@ __scbrt_la_vscbrt_ha_cout_data:
 	.long	0xbd288f47
 	.type	.L_2il0floatpacket.35,@object
 	.size	.L_2il0floatpacket.35,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cos_d_la.s
+++ b/linux/avx512/svml_z0_cos_d_la.s
@@ -17672,3 +17672,5 @@ __dcos_la_CoutTab:
 	.long	2146435072
 	.type	__dcos_la_CoutTab,@object
 	.size	__dcos_la_CoutTab,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cos_s_la.s
+++ b/linux/avx512/svml_z0_cos_s_la.s
@@ -2852,3 +2852,5 @@ __scos_la__vmlsCosCoutTab:
 	.long	2139095040
 	.type	__scos_la__vmlsCosCoutTab,@object
 	.size	__scos_la__vmlsCosCoutTab,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cosh_d_la.s
+++ b/linux/avx512/svml_z0_cosh_d_la.s
@@ -1713,3 +1713,5 @@ __dcosh_la_CoutTab:
 	.long	1077247184
 	.type	__dcosh_la_CoutTab,@object
 	.size	__dcosh_la_CoutTab,1152
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cosh_s_la.s
+++ b/linux/avx512/svml_z0_cosh_s_la.s
@@ -1209,3 +1209,5 @@ __scosh_la_CoutTab:
 	.long	1077247184
 	.type	__scosh_la_CoutTab,@object
 	.size	__scosh_la_CoutTab,1152
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp2_d_la.s
+++ b/linux/avx512/svml_z0_exp2_d_la.s
@@ -828,3 +828,5 @@ __dexp2_la__imldExp2HATab:
 	.long	0
 	.type	__dexp2_la__imldExp2HATab,@object
 	.size	__dexp2_la__imldExp2HATab,1152
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp2_s_la.s
+++ b/linux/avx512/svml_z0_exp2_s_la.s
@@ -492,3 +492,5 @@ __svml_sexp2_data_internal_avx512:
 	.long	0xc2fc0000
 	.type	.L_2il0floatpacket.56,@object
 	.size	.L_2il0floatpacket.56,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp_d_la.s
+++ b/linux/avx512/svml_z0_exp_d_la.s
@@ -1072,3 +1072,5 @@ _imldExpHATab:
 	.long	1106771968
 	.type	_imldExpHATab,@object
 	.size	_imldExpHATab,1176
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp_s_la.s
+++ b/linux/avx512/svml_z0_exp_s_la.s
@@ -770,3 +770,5 @@ __svml_sexp_data_internal_avx512:
 	.long	0x40000000
 	.type	.L_2il0floatpacket.67,@object
 	.size	.L_2il0floatpacket.67,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_expm1_d_la.s
+++ b/linux/avx512/svml_z0_expm1_d_la.s
@@ -1087,3 +1087,5 @@ _imldExpHATab:
 	.long	0x00000000,0xbff00000
 	.type	.L_2il0floatpacket.77,@object
 	.size	.L_2il0floatpacket.77,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_expm1_s_la.s
+++ b/linux/avx512/svml_z0_expm1_s_la.s
@@ -591,3 +591,5 @@ __svml_sexpm1_data_internal_avx512:
 	.long	0x3c0950ef
 	.type	.L_2il0floatpacket.56,@object
 	.size	.L_2il0floatpacket.56,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log10_d_la.s
+++ b/linux/avx512/svml_z0_log10_d_la.s
@@ -1122,3 +1122,5 @@ __dlog10_la_CoutTab:
 	.long	0x00000000,0x3ff00000
 	.type	.L_2il0floatpacket.89,@object
 	.size	.L_2il0floatpacket.89,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log10_s_la.s
+++ b/linux/avx512/svml_z0_log10_s_la.s
@@ -752,3 +752,5 @@ __slog10_la_CoutTab:
 	.long	0x3f800000
 	.type	.L_2il0floatpacket.93,@object
 	.size	.L_2il0floatpacket.93,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log1p_d_la.s
+++ b/linux/avx512/svml_z0_log1p_d_la.s
@@ -1130,3 +1130,5 @@ __dlog1p_la_CoutTab:
 	.long	0x00000000,0x3ff00000
 	.type	.L_2il0floatpacket.81,@object
 	.size	.L_2il0floatpacket.81,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log1p_s_la.s
+++ b/linux/avx512/svml_z0_log1p_s_la.s
@@ -1648,3 +1648,5 @@ __slog1p_la_CoutTab:
 	.long	0x3f800000
 	.type	.L_2il0floatpacket.90,@object
 	.size	.L_2il0floatpacket.90,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log2_d_la.s
+++ b/linux/avx512/svml_z0_log2_d_la.s
@@ -1712,3 +1712,5 @@ __dlog2_la__P:
 	.long	1073157447
 	.type	__dlog2_la__P,@object
 	.size	__dlog2_la__P,56
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log2_s_la.s
+++ b/linux/avx512/svml_z0_log2_s_la.s
@@ -726,3 +726,5 @@ __slog2_la_CoutTab:
 	.long	0x3f800000
 	.type	.L_2il0floatpacket.90,@object
 	.size	.L_2il0floatpacket.90,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log_d_la.s
+++ b/linux/avx512/svml_z0_log_d_la.s
@@ -1094,3 +1094,5 @@ __dlog_la_CoutTab:
 	.long	0x00000000,0x3ff00000
 	.type	.L_2il0floatpacket.80,@object
 	.size	.L_2il0floatpacket.80,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log_s_la.s
+++ b/linux/avx512/svml_z0_log_s_la.s
@@ -928,3 +928,5 @@ _imlsLnHATab:
 	.long	0x00000000,0x3ff00000
 	.type	.L_2il0floatpacket.73,@object
 	.size	.L_2il0floatpacket.73,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_pow_d_la.s
+++ b/linux/avx512/svml_z0_pow_d_la.s
@@ -3523,3 +3523,5 @@ __dpow_la_CoutTab:
 	.long	862978048
 	.type	__dpow_la_CoutTab,@object
 	.size	__dpow_la_CoutTab,6880
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_pow_s_la.s
+++ b/linux/avx512/svml_z0_pow_s_la.s
@@ -2010,3 +2010,5 @@ __spow_la_CoutTab:
 	.long	0x3f800000
 	.type	.L_2il0floatpacket.136,@object
 	.size	.L_2il0floatpacket.136,4
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_sin_d_la.s
+++ b/linux/avx512/svml_z0_sin_d_la.s
@@ -17542,3 +17542,5 @@ __dsin_la_CoutTab:
 	.long	2146435072
 	.type	__dsin_la_CoutTab,@object
 	.size	__dsin_la_CoutTab,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_sin_s_la.s
+++ b/linux/avx512/svml_z0_sin_s_la.s
@@ -2749,3 +2749,5 @@ __ssin_la__vmlsSinHATab:
 	.long	2139095040
 	.type	__ssin_la__vmlsSinHATab,@object
 	.size	__ssin_la__vmlsSinHATab,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_sinh_d_la.s
+++ b/linux/avx512/svml_z0_sinh_d_la.s
@@ -2050,3 +2050,5 @@ __dsinh_la_CoutTab:
 	.long	0x00000000,0x80000000,0x00000000,0x00000000
 	.type	.L_2il0floatpacket.97,@object
 	.size	.L_2il0floatpacket.97,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_sinh_s_la.s
+++ b/linux/avx512/svml_z0_sinh_s_la.s
@@ -1444,3 +1444,5 @@ __ssinh_la_CoutTab:
 	.long	0x00000000,0x80000000,0x00000000,0x00000000
 	.type	.L_2il0floatpacket.98,@object
 	.size	.L_2il0floatpacket.98,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_tan_d_la.s
+++ b/linux/avx512/svml_z0_tan_d_la.s
@@ -20217,3 +20217,5 @@ __dtan_la_Tab:
 	.long	2146435072
 	.type	__dtan_la_Tab,@object
 	.size	__dtan_la_Tab,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_tan_s_la.s
+++ b/linux/avx512/svml_z0_tan_s_la.s
@@ -3175,3 +3175,5 @@ __stan_la__vmlsTanTab:
 	.long	2139095040
 	.type	__stan_la__vmlsTanTab,@object
 	.size	__stan_la__vmlsTanTab,8
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_tanh_d_la.s
+++ b/linux/avx512/svml_z0_tanh_d_la.s
@@ -3044,3 +3044,5 @@ __dtanh_la__imldTanhTab:
 	.long	3220176896
 	.type	__dtanh_la__imldTanhTab,@object
 	.size	__dtanh_la__imldTanhTab,16
+
+      .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_tanh_s_la.s
+++ b/linux/avx512/svml_z0_tanh_s_la.s
@@ -1789,3 +1789,5 @@ __stanh_la__imlsTanhTab:
 	.long	3212836864
 	.type	__stanh_la__imlsTanhTab,@object
 	.size	__stanh_la__imlsTanhTab,8
+
+      .section        .note.GNU-stack,"",@progbits


### PR DESCRIPTION
These asm files needs .note.GNU-stack marker to ensure the final
binary doesnt contain an executable stack.