### PR TITLE
Add SVML AVX512 FP16 content

### DIFF
--- a/linux/avx512/svml_z0_acos_h_la.s
+++ b/linux/avx512/svml_z0_acos_h_la.s
@@ -44,7 +44,7 @@ __svml_acoss32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_acos_h

--- a/linux/avx512/svml_z0_acos_h_la.s
+++ b/linux/avx512/svml_z0_acos_h_la.s
@@ -1,0 +1,114 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *      SelMask = (|x| >= 0.5) ? 1 : 0;
+ *      R = SelMask ? sqrt(0.5 - 0.5*|x|) : |x|
+ *      acos(|x|) = SelMask ? 2*Poly(R) : (Pi/2 - Poly(R))
+ *      acos(x) = sign(x) ? (Pi - acos(|x|)) : acos(|x|)
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_acoss32
+
+__svml_acoss32:
+
+        .cfi_startproc
+
+        vmovdqu16 64+__svml_hacos_data_internal(%rip), %zmm1
+        vmovdqu16 192+__svml_hacos_data_internal(%rip), %zmm5
+        vmovdqu16 320+__svml_hacos_data_internal(%rip), %zmm7
+
+/* High = Pi2 for |x|<0.5, else Pi for x<-0.5, 0 for x>0.5 */
+        vmovdqu16 128+__svml_hacos_data_internal(%rip), %zmm3
+
+/* set xa = -2*y if SelMask=1 */
+        vmovdqu16 448+__svml_hacos_data_internal(%rip), %zmm11
+        vmovdqu16 384+__svml_hacos_data_internal(%rip), %zmm9
+
+/* x^2 */
+        vmulph    {rn-sae}, %zmm0, %zmm0, %zmm2
+
+/* y = 0.5 -0.5*|x| */
+        vmovaps   %zmm1, %zmm10
+
+/*
+ * No callout
+ * xa = |x|
+ */
+        vpandd    __svml_hacos_data_internal(%rip), %zmm0, %zmm12
+        vfnmadd231ph {rn-sae}, %zmm12, %zmm1, %zmm10
+
+/* SelMask=1 for |x|>=0.5 */
+        vcmpph    $21, {sae}, %zmm1, %zmm12, %k2
+
+/* set y = y*rsqrt(y) ~ sqrt(y) */
+        vrsqrtph  %zmm10, %zmm6
+
+/* SqrtMask=0 if y==+/-0 */
+        vcmpph    $4, {sae}, %zmm5, %zmm10, %k1
+
+/* set x2=y for |x|>=0.5 */
+        vminph    {sae}, %zmm10, %zmm2, %zmm8
+        vmulph    {rn-sae}, %zmm6, %zmm10, %zmm10{%k1}
+
+/* sign(x) */
+        vpxord    %zmm0, %zmm12, %zmm13
+
+/* polynomial */
+        vmovdqu16 256+__svml_hacos_data_internal(%rip), %zmm0
+        vmulph    {rn-sae}, %zmm11, %zmm10, %zmm12{%k2}
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm7, %zmm8, %zmm0
+        vfmadd213ph {rn-sae}, %zmm9, %zmm8, %zmm0
+        vpxord    %zmm3, %zmm13, %zmm4
+        vsubph    {rn-sae}, %zmm4, %zmm3, %zmm3{%k2}
+        vpxord    %zmm13, %zmm12, %zmm14
+
+/* result */
+        vfnmadd213ph {rn-sae}, %zmm3, %zmm14, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_acoss32,@function
+        .size	__svml_acoss32,.-__svml_acoss32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hacos_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x3800
+	.endr
+	.rept	32
+        .word	0x3e48
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+	.rept	32
+        .word	0x2e26
+	.endr
+	.rept	32
+        .word	0x3144
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0xc000
+	.endr
+        .type	__svml_hacos_data_internal,@object
+        .size	__svml_hacos_data_internal,512

--- a/linux/avx512/svml_z0_acos_h_la.s
+++ b/linux/avx512/svml_z0_acos_h_la.s
@@ -143,3 +143,4 @@ __svml_hacos_data_internal:
 	.endr
         .type	__svml_hacos_data_internal,@object
         .size	__svml_hacos_data_internal,512
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_acosh_h_la.s
+++ b/linux/avx512/svml_z0_acosh_h_la.s
@@ -26,25 +26,51 @@
 __svml_acoshs32:
 
         .cfi_startproc
-
+        vmovdqu16 __svml_hacosh_data_internal(%rip), %zmm13
+        vmovdqu16 64+__svml_hacosh_data_internal(%rip), %zmm1
+        vmovdqu16 128+__svml_hacosh_data_internal(%rip), %zmm31
+        vmovdqu16 192+__svml_hacosh_data_internal(%rip), %zmm30
+        vmovdqu16 256+__svml_hacosh_data_internal(%rip), %zmm29
+        vmovdqu16 320+__svml_hacosh_data_internal(%rip), %zmm28
+        vmovdqu16 384+__svml_hacosh_data_internal(%rip), %zmm10
+        vmovdqu16 448+__svml_hacosh_data_internal(%rip), %zmm12
+        vmovdqu16 512+__svml_hacosh_data_internal(%rip), %zmm27
+        vmovdqu16 576+__svml_hacosh_data_internal(%rip), %zmm24
+        vmovdqu16 640+__svml_hacosh_data_internal(%rip), %zmm26
+        vmovdqu16 704+__svml_hacosh_data_internal(%rip), %zmm25
+        vmovdqu16 768+__svml_hacosh_data_internal(%rip), %zmm23
+        kxnord  %k7, %k7, %k7
 /*
  * No callout
  * x in [1,2): acosh(x) ~ poly(x-1)*sqrt(x-1)
  * hY = x-1
  */
-        vmovdqu16 __svml_hacosh_data_internal(%rip), %zmm13
 
-/* c0+c1*Y+c2*Y^2 */
-        vmovdqu16 128+__svml_hacosh_data_internal(%rip), %zmm8
-        vmovdqu16 192+__svml_hacosh_data_internal(%rip), %zmm4
-        vmovdqu16 256+__svml_hacosh_data_internal(%rip), %zmm6
+/* npy_half* in -> %rdi, npy_half* out -> %rsi, size_t N -> %rdx */
+.looparray_acosh_h:
+        cmpq    $31, %rdx
+        ja .loaddata_acosh
+/* set up mask %k7 for masked load instruction */
+        movl    $1, %eax
+        movl    %edx, %ecx
+        sall    %cl, %eax
+        subl    $1, %eax
+        kmovd   %eax, %k7
+/* Constant required for masked load */
+        movl    $15360, %eax
+        vpbroadcastw    %eax, %zmm0
+        vmovdqu16 (%rdi), %zmm0{%k7}
+        jmp .funcbegin_acosh_h
+.loaddata_acosh:
+        vmovdqu16 (%rdi), %zmm0
+        addq $64, %rdi
+        
+.funcbegin_acosh_h:
 
-/* log(1+sqrt(1-z*z)) ~ cs0+cs1*z+cs2*z^2 */
-        vmovdqu16 384+__svml_hacosh_data_internal(%rip), %zmm10
-        vmovdqu16 448+__svml_hacosh_data_internal(%rip), %zmm12
+/* ReLoad constants */
+	vmovdqu16 %zmm31, %zmm8
+	vmovdqu16 %zmm29, %zmm6
 
-/* SelMask=1 for |x|>=2.0 */
-        vmovdqu16 64+__svml_hacosh_data_internal(%rip), %zmm1
         vmovaps   %zmm0, %zmm3
         vsubph    {rn-sae}, %zmm13, %zmm3, %zmm5
 
@@ -58,21 +84,21 @@ __svml_acoshs32:
 /*
  * x>=2: acosh(x) = log(x) + log(1+sqrt(1-(1/x)^2))
  * Z ~ 1/x in (0, 0.5]
+        vmovdqu16 256+__svml_hacosh_data_internal(%rip), %zmm29
  */
         vrcpph    %zmm3, %zmm11
 
 /* hRS ~ 1/sqrt(x-1) */
         vrsqrtph  %zmm5, %zmm7
         vcmpph    $21, {sae}, %zmm1, %zmm3, %k1
-        vmovdqu16 320+__svml_hacosh_data_internal(%rip), %zmm0
-        vfmadd213ph {rn-sae}, %zmm4, %zmm5, %zmm8
+        vmovdqu16 %zmm28, %zmm0
+        vfmadd213ph {rn-sae}, %zmm30, %zmm5, %zmm8
 
 /* hS ~ sqrt(x-1) */
         vrcpph    %zmm7, %zmm9
 
 /* log(1+R)/R */
-        vmovdqu16 512+__svml_hacosh_data_internal(%rip), %zmm7
-        vmovdqu16 640+__svml_hacosh_data_internal(%rip), %zmm4
+        vmovdqu16 %zmm27, %zmm7
         vfmadd213ph {rn-sae}, %zmm6, %zmm5, %zmm8
 
 /* mantissa - 1 */
@@ -81,26 +107,32 @@ __svml_acoshs32:
 
 /* exponent correction */
         vgetexpph {sae}, %zmm14, %zmm14
-        vmovdqu16 704+__svml_hacosh_data_internal(%rip), %zmm5
 
 /* poly(x-1)*sqrt(x-1) */
         vmulph    {rn-sae}, %zmm9, %zmm8, %zmm2
         vfmadd213ph {rn-sae}, %zmm12, %zmm11, %zmm0
         vsubph    {rn-sae}, %zmm14, %zmm15, %zmm8
-        vmovdqu16 576+__svml_hacosh_data_internal(%rip), %zmm15
+        vmovdqu16 %zmm24, %zmm15
         vfmadd213ph {rn-sae}, %zmm15, %zmm6, %zmm7
-        vfmadd213ph {rn-sae}, %zmm4, %zmm6, %zmm7
-        vfmadd213ph {rn-sae}, %zmm5, %zmm6, %zmm7
+        vfmadd213ph {rn-sae}, %zmm26, %zmm6, %zmm7
+        vfmadd213ph {rn-sae}, %zmm25, %zmm6, %zmm7
 
 /* log(1+R) + log(1+sqrt(1-z*z)) */
         vfmadd213ph {rn-sae}, %zmm0, %zmm6, %zmm7
 
 /* result for x>=2 */
-        vmovdqu16 768+__svml_hacosh_data_internal(%rip), %zmm0
+        vmovdqu16 %zmm23, %zmm0
         vfmadd213ph {rn-sae}, %zmm7, %zmm0, %zmm8
 
 /* result = SelMask?  hPl : hPa */
         vpblendmw %zmm8, %zmm2, %zmm0{%k1}
+
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray_acosh_h
         ret
 
         .cfi_endproc

--- a/linux/avx512/svml_z0_acosh_h_la.s
+++ b/linux/avx512/svml_z0_acosh_h_la.s
@@ -185,3 +185,4 @@ __svml_hacosh_data_internal:
 	.endr
         .type	__svml_hacosh_data_internal,@object
         .size	__svml_hacosh_data_internal,832
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_acosh_h_la.s
+++ b/linux/avx512/svml_z0_acosh_h_la.s
@@ -1,0 +1,155 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Compute acosh(x) as log(x + sqrt(x*x - 1))
+ *
+ *   Special cases:
+ *
+ *   acosh(NaN)  = quiet NaN, and raise invalid exception
+ *   acosh(-INF) = NaN
+ *   acosh(+INF) = +INF
+ *   acosh(x)    = NaN if x < 1
+ *   acosh(1)    = +0
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_acoshs32
+
+__svml_acoshs32:
+
+        .cfi_startproc
+
+/*
+ * No callout
+ * x in [1,2): acosh(x) ~ poly(x-1)*sqrt(x-1)
+ * hY = x-1
+ */
+        vmovdqu16 __svml_hacosh_data_internal(%rip), %zmm13
+
+/* c0+c1*Y+c2*Y^2 */
+        vmovdqu16 128+__svml_hacosh_data_internal(%rip), %zmm8
+        vmovdqu16 192+__svml_hacosh_data_internal(%rip), %zmm4
+        vmovdqu16 256+__svml_hacosh_data_internal(%rip), %zmm6
+
+/* log(1+sqrt(1-z*z)) ~ cs0+cs1*z+cs2*z^2 */
+        vmovdqu16 384+__svml_hacosh_data_internal(%rip), %zmm10
+        vmovdqu16 448+__svml_hacosh_data_internal(%rip), %zmm12
+
+/* SelMask=1 for |x|>=2.0 */
+        vmovdqu16 64+__svml_hacosh_data_internal(%rip), %zmm1
+        vmovaps   %zmm0, %zmm3
+        vsubph    {rn-sae}, %zmm13, %zmm3, %zmm5
+
+/*
+ * log(x)
+ * GetMant(x), normalized to [.75,1.5) for x>=0, NaN for x<0
+ */
+        vgetmantph $11, {sae}, %zmm3, %zmm14
+        vgetexpph {sae}, %zmm3, %zmm15
+
+/*
+ * x>=2: acosh(x) = log(x) + log(1+sqrt(1-(1/x)^2))
+ * Z ~ 1/x in (0, 0.5]
+ */
+        vrcpph    %zmm3, %zmm11
+
+/* hRS ~ 1/sqrt(x-1) */
+        vrsqrtph  %zmm5, %zmm7
+        vcmpph    $21, {sae}, %zmm1, %zmm3, %k1
+        vmovdqu16 320+__svml_hacosh_data_internal(%rip), %zmm0
+        vfmadd213ph {rn-sae}, %zmm4, %zmm5, %zmm8
+
+/* hS ~ sqrt(x-1) */
+        vrcpph    %zmm7, %zmm9
+
+/* log(1+R)/R */
+        vmovdqu16 512+__svml_hacosh_data_internal(%rip), %zmm7
+        vmovdqu16 640+__svml_hacosh_data_internal(%rip), %zmm4
+        vfmadd213ph {rn-sae}, %zmm6, %zmm5, %zmm8
+
+/* mantissa - 1 */
+        vsubph    {rn-sae}, %zmm13, %zmm14, %zmm6
+        vfmadd213ph {rn-sae}, %zmm10, %zmm11, %zmm0
+
+/* exponent correction */
+        vgetexpph {sae}, %zmm14, %zmm14
+        vmovdqu16 704+__svml_hacosh_data_internal(%rip), %zmm5
+
+/* poly(x-1)*sqrt(x-1) */
+        vmulph    {rn-sae}, %zmm9, %zmm8, %zmm2
+        vfmadd213ph {rn-sae}, %zmm12, %zmm11, %zmm0
+        vsubph    {rn-sae}, %zmm14, %zmm15, %zmm8
+        vmovdqu16 576+__svml_hacosh_data_internal(%rip), %zmm15
+        vfmadd213ph {rn-sae}, %zmm15, %zmm6, %zmm7
+        vfmadd213ph {rn-sae}, %zmm4, %zmm6, %zmm7
+        vfmadd213ph {rn-sae}, %zmm5, %zmm6, %zmm7
+
+/* log(1+R) + log(1+sqrt(1-z*z)) */
+        vfmadd213ph {rn-sae}, %zmm0, %zmm6, %zmm7
+
+/* result for x>=2 */
+        vmovdqu16 768+__svml_hacosh_data_internal(%rip), %zmm0
+        vfmadd213ph {rn-sae}, %zmm7, %zmm0, %zmm8
+
+/* result = SelMask?  hPl : hPa */
+        vpblendmw %zmm8, %zmm2, %zmm0{%k1}
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_acoshs32,@function
+        .size	__svml_acoshs32,.-__svml_acoshs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hacosh_data_internal:
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x4000
+	.endr
+	.rept	32
+        .word	0x24a4
+	.endr
+	.rept	32
+        .word	0xaf5e
+	.endr
+	.rept	32
+        .word	0x3da8
+	.endr
+	.rept	32
+        .word	0xb4d2
+	.endr
+	.rept	32
+        .word	0x231d
+	.endr
+	.rept	32
+        .word	0x398b
+	.endr
+	.rept	32
+        .word	0xb22b
+	.endr
+	.rept	32
+        .word	0x358b
+	.endr
+	.rept	32
+        .word	0xb807
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+        .type	__svml_hacosh_data_internal,@object
+        .size	__svml_hacosh_data_internal,832

--- a/linux/avx512/svml_z0_asin_h_la.s
+++ b/linux/avx512/svml_z0_asin_h_la.s
@@ -42,7 +42,7 @@ __svml_asins32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_asin_h

--- a/linux/avx512/svml_z0_asin_h_la.s
+++ b/linux/avx512/svml_z0_asin_h_la.s
@@ -1,0 +1,112 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *      SelMask = (|x| >= 0.5) ? 1 : 0;
+ *      R = SelMask ? sqrt(0.5 - 0.5*|x|) : |x|
+ *      asin(x) = (SelMask ? (Pi/2 - 2*Poly(R)) : Poly(R))*(-1)^sign(x)
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_asins32
+
+__svml_asins32:
+
+        .cfi_startproc
+
+        vmovdqu16 64+__svml_hasin_data_internal(%rip), %zmm1
+
+/* High = SelMask? Pi2 : 0 */
+        vmovdqu16 192+__svml_hasin_data_internal(%rip), %zmm3
+
+/* polynomial */
+        vmovdqu16 256+__svml_hasin_data_internal(%rip), %zmm12
+        vmovdqu16 320+__svml_hasin_data_internal(%rip), %zmm5
+        vmovdqu16 384+__svml_hasin_data_internal(%rip), %zmm7
+
+/* set xa = -2*y if SelMask=1 */
+        vmovdqu16 448+__svml_hasin_data_internal(%rip), %zmm9
+
+/* x^2 */
+        vmulph    {rn-sae}, %zmm0, %zmm0, %zmm2
+
+/* y = 0.5 -0.5*|x| */
+        vmovaps   %zmm1, %zmm8
+
+/*
+ * No callout
+ * xa = |x|
+ */
+        vpandd    __svml_hasin_data_internal(%rip), %zmm0, %zmm10
+        vfnmadd231ph {rn-sae}, %zmm10, %zmm1, %zmm8
+
+/* SelMask=1 for |x|>=0.5 */
+        vcmpph    $21, {sae}, %zmm1, %zmm10, %k2
+
+/* set y = y*rsqrt(y) ~ sqrt(y) */
+        vrsqrtph  %zmm8, %zmm4
+
+/* SqrtMask=0 if y==+/-0 */
+        vcmpph    $4, {sae}, %zmm3, %zmm8, %k1
+
+/* set x2=y for |x|>=0.5 */
+        vminph    {sae}, %zmm8, %zmm2, %zmm6
+        vpblendmw 128+__svml_hasin_data_internal(%rip), %zmm3, %zmm11{%k2}
+        vmulph    {rn-sae}, %zmm4, %zmm8, %zmm8{%k1}
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm5, %zmm6, %zmm12
+        vfmadd213ph {rn-sae}, %zmm7, %zmm6, %zmm12
+
+/* sign(x) */
+        vpxord    %zmm0, %zmm10, %zmm13
+        vmulph    {rn-sae}, %zmm9, %zmm8, %zmm10{%k2}
+
+/* result */
+        vfmadd213ph {rn-sae}, %zmm11, %zmm10, %zmm12
+        vpxord    %zmm13, %zmm12, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_asins32,@function
+        .size	__svml_asins32,.-__svml_asins32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hasin_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x3800
+	.endr
+	.rept	32
+        .word	0x3e48
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+	.rept	32
+        .word	0x2e26
+	.endr
+	.rept	32
+        .word	0x3144
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0xc000
+	.endr
+        .type	__svml_hasin_data_internal,@object
+        .size	__svml_hasin_data_internal,512

--- a/linux/avx512/svml_z0_asin_h_la.s
+++ b/linux/avx512/svml_z0_asin_h_la.s
@@ -133,3 +133,4 @@ __svml_hasin_data_internal:
 	.endr
         .type	__svml_hasin_data_internal,@object
         .size	__svml_hasin_data_internal,512
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_asinh_h_la.s
+++ b/linux/avx512/svml_z0_asinh_h_la.s
@@ -48,7 +48,7 @@ __svml_asinhs32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_asinh_h

--- a/linux/avx512/svml_z0_asinh_h_la.s
+++ b/linux/avx512/svml_z0_asinh_h_la.s
@@ -1,0 +1,154 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *    Compute log(x+sqrt(x*x+1)) using RSQRT for starting the
+ *    square root approximation, and small table lookups for log
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_asinhs32
+
+__svml_asinhs32:
+
+        .cfi_startproc
+
+/* |x| in [0, 1) : result = x+x*poly(x) */
+        vmovdqu16 192+__svml_hasinh_data_internal(%rip), %zmm5
+        vmovdqu16 128+__svml_hasinh_data_internal(%rip), %zmm2
+        vmovdqu16 256+__svml_hasinh_data_internal(%rip), %zmm6
+
+/* SelMask=1 for |x|>=1.0 */
+        vmovdqu16 __svml_hasinh_data_internal(%rip), %zmm1
+
+/* log(1+sqrt(1+y^2)) ~ poly2(y);  y in (0,1] */
+        vmovdqu16 448+__svml_hasinh_data_internal(%rip), %zmm8
+        vmovdqu16 704+__svml_hasinh_data_internal(%rip), %zmm15
+        vmovdqu16 320+__svml_hasinh_data_internal(%rip), %zmm7
+        vmovdqu16 512+__svml_hasinh_data_internal(%rip), %zmm9
+        vmovdqu16 576+__svml_hasinh_data_internal(%rip), %zmm11
+
+/*
+ * No callout
+ * |x|
+ */
+        vpandd    64+__svml_hasinh_data_internal(%rip), %zmm0, %zmm4
+        vfmadd213ph {rn-sae}, %zmm5, %zmm4, %zmm2
+
+/*
+ * log(|x|)
+ * GetMant(x), normalized to [.75,1.5) for x>=0, NaN for x<0
+ */
+        vgetmantph $11, {sae}, %zmm4, %zmm12
+
+/*
+ * |x|>=1:  result = log(x) + log(1+sqrt(1+(1/x)^2))
+ * y = 1/|x|
+ */
+        vrcpph    %zmm4, %zmm10
+        vgetexpph {sae}, %zmm4, %zmm13
+        vcmpph    $21, {sae}, %zmm1, %zmm4, %k1
+
+/* exponent correction */
+        vgetexpph {sae}, %zmm12, %zmm14
+        vfmadd213ph {rn-sae}, %zmm6, %zmm4, %zmm2
+
+/* mantissa - 1 */
+        vsubph    {rn-sae}, %zmm1, %zmm12, %zmm5
+
+/* log(1+R)/R */
+        vmovdqu16 640+__svml_hasinh_data_internal(%rip), %zmm6
+        vmovdqu16 768+__svml_hasinh_data_internal(%rip), %zmm12
+        vfmadd213ph {rn-sae}, %zmm7, %zmm4, %zmm2
+        vsubph    {rn-sae}, %zmm14, %zmm13, %zmm7
+        vfmadd213ph {rn-sae}, %zmm15, %zmm5, %zmm6
+        vmovdqu16 832+__svml_hasinh_data_internal(%rip), %zmm13
+        vfmadd213ph {rn-sae}, %zmm4, %zmm4, %zmm2
+        vfmadd213ph {rn-sae}, %zmm12, %zmm5, %zmm6
+        vfmadd213ph {rn-sae}, %zmm13, %zmm5, %zmm6
+
+/* save sign */
+        vpxord    %zmm4, %zmm0, %zmm3
+        vmovdqu16 384+__svml_hasinh_data_internal(%rip), %zmm0
+        vfmadd213ph {rn-sae}, %zmm8, %zmm10, %zmm0
+        vfmadd213ph {rn-sae}, %zmm9, %zmm10, %zmm0
+        vfmadd213ph {rn-sae}, %zmm11, %zmm10, %zmm0
+
+/* log(1+R) + log(1+sqrt(1+y*y)) */
+        vfmadd213ph {rn-sae}, %zmm0, %zmm5, %zmm6
+
+/* result for x>=2 */
+        vmovdqu16 896+__svml_hasinh_data_internal(%rip), %zmm0
+        vfmadd213ph {rn-sae}, %zmm6, %zmm0, %zmm7
+
+/* result = SelMask?  hPl : hPa */
+        vpblendmw %zmm7, %zmm2, %zmm1{%k1}
+
+/* set sign */
+        vpxord    %zmm3, %zmm1, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_asinhs32,@function
+        .size	__svml_asinhs32,.-__svml_asinhs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hasinh_data_internal:
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x2c52
+	.endr
+	.rept	32
+        .word	0xb206
+	.endr
+	.rept	32
+        .word	0x185d
+	.endr
+	.rept	32
+        .word	0x8057
+	.endr
+	.rept	32
+        .word	0xadb6
+	.endr
+	.rept	32
+        .word	0x347f
+	.endr
+	.rept	32
+        .word	0x9b9e
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+	.rept	32
+        .word	0xb22b
+	.endr
+	.rept	32
+        .word	0x358b
+	.endr
+	.rept	32
+        .word	0xb807
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+        .type	__svml_hasinh_data_internal,@object
+        .size	__svml_hasinh_data_internal,960

--- a/linux/avx512/svml_z0_asinh_h_la.s
+++ b/linux/avx512/svml_z0_asinh_h_la.s
@@ -181,3 +181,4 @@ __svml_hasinh_data_internal:
 	.endr
         .type	__svml_hasinh_data_internal,@object
         .size	__svml_hasinh_data_internal,960
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan2_h_la.s
+++ b/linux/avx512/svml_z0_atan2_h_la.s
@@ -1,0 +1,252 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Absolute arguments: xa = |x|
+ *                       ya = |y|
+ *   Argument signs: sign(x)
+ *                   sign(x)
+ *   High = (sgn_x)? Pi: 0
+ *   Mask for difference: diff_msk = (xa<ya) ? 1 : 0;
+ *   Maximum and minimum: xa1=max(xa,ya)
+ *   ya1=min(ya,xa)
+ *
+ *   if(diff_msk) High = Pi2;
+ *
+ *   Get result sign: sgn_r = -sgn_x for diff_msk=1
+ *   Divide: xa = ya1/xa1
+ *   set branch mask if xa1 is Inf/NaN/zero
+ *
+ *   Result: High + xa*Poly
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_atan2s32
+
+__svml_atan2s32:
+
+        .cfi_startproc
+
+        pushq     %rbp
+        .cfi_def_cfa_offset 16
+        movq      %rsp, %rbp
+        .cfi_def_cfa 6, 16
+        .cfi_offset 6, -16
+        andq      $-64, %rsp
+        subq      $256, %rsp
+        vmovdqu16 __svml_hatan2_data_internal(%rip), %zmm5
+        vmovdqu16 384+__svml_hatan2_data_internal(%rip), %zmm13
+        vmovdqu16 448+__svml_hatan2_data_internal(%rip), %zmm14
+        vmovdqu16 512+__svml_hatan2_data_internal(%rip), %zmm15
+        vmovaps   %zmm1, %zmm4
+        vmovdqu16 64+__svml_hatan2_data_internal(%rip), %zmm1
+
+/* xa = |x| */
+        vpandd    %zmm5, %zmm4, %zmm8
+
+/* ya = |y| */
+        vpandd    %zmm5, %zmm0, %zmm7
+
+/* diff_msk = (xa<ya) ? 1 : 0; */
+        vcmpph    $17, {sae}, %zmm7, %zmm8, %k1
+
+/* xa1=max(xa,ya) */
+        vmaxph    {sae}, %zmm7, %zmm8, %zmm12
+
+/* ya1=min(ya,xa) */
+        vminph    {sae}, %zmm8, %zmm7, %zmm11
+
+/* set branch mask if xa1 is Inf/NaN/zero */
+        vfpclassph $159, %zmm12, %k0
+        kmovd     %k0, %edx
+
+/* sign(x) */
+        vpxord    %zmm4, %zmm8, %zmm2
+
+/* sgn_r = -sgn_x for diff_msk=1 */
+        vpxord    256+__svml_hatan2_data_internal(%rip), %zmm2, %zmm10
+
+/* High = (sgn_x)? Pi: 0 */
+        vpsraw    $15, %zmm2, %zmm6
+        vmovdqu16 %zmm10, %zmm2{%k1}
+
+/* xa = ya1/xa1 */
+        vdivph    {rn-sae}, %zmm12, %zmm11, %zmm10
+
+/* polynomial */
+        vmovdqu16 320+__svml_hatan2_data_internal(%rip), %zmm12
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm13, %zmm10, %zmm12
+        vfmadd213ph {rn-sae}, %zmm14, %zmm10, %zmm12
+        vfmadd213ph {rn-sae}, %zmm15, %zmm10, %zmm12
+        vfmadd213ph {rn-sae}, %zmm1, %zmm10, %zmm12
+        vpandd    128+__svml_hatan2_data_internal(%rip), %zmm6, %zmm9
+
+/* if(diff_msk) High = Pi2; */
+        vpblendmw 192+__svml_hatan2_data_internal(%rip), %zmm9, %zmm5{%k1}
+
+/* set polynomial sign */
+        vpxord    %zmm2, %zmm12, %zmm1
+
+/* High + xa*Poly */
+        vfmadd213ph {rn-sae}, %zmm5, %zmm10, %zmm1
+
+/* sign(x) */
+        vpxord    %zmm0, %zmm7, %zmm3
+
+/* set sign */
+        vpxord    %zmm3, %zmm1, %zmm1
+        testl     %edx, %edx
+
+/* Go to special inputs processing branch */
+        jne       .LBL_SPECIAL_VALUES_BRANCH
+                                # LOE rbx r12 r13 r14 r15 edx zmm0 zmm1 zmm4
+
+/* Restore registers
+ * and exit the function
+ */
+
+.LBL_EXIT:
+        vmovaps   %zmm1, %zmm0
+        movq      %rbp, %rsp
+        popq      %rbp
+        .cfi_def_cfa 7, 8
+        .cfi_restore 6
+        ret
+        .cfi_def_cfa 6, 16
+        .cfi_offset 6, -16
+
+/* Branch to process
+ * special inputs
+ */
+
+.LBL_SPECIAL_VALUES_BRANCH:
+        vmovups   %zmm0, 64(%rsp)
+        vmovups   %zmm4, 128(%rsp)
+        vmovups   %zmm1, 192(%rsp)
+                                # LOE rbx r12 r13 r14 r15 edx
+
+        xorl      %eax, %eax
+        movq      %r12, 16(%rsp)
+        /*  DW_CFA_expression: r12 (r12) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -240; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0c, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x10, 0xff, 0xff, 0xff, 0x22
+        movl      %eax, %r12d
+        movq      %r13, 8(%rsp)
+        /*  DW_CFA_expression: r13 (r13) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -248; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0d, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x08, 0xff, 0xff, 0xff, 0x22
+        movl      %edx, %r13d
+        movq      %r14, (%rsp)
+        /*  DW_CFA_expression: r14 (r14) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -256; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0e, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x00, 0xff, 0xff, 0xff, 0x22
+                                # LOE rbx r15 r12d r13d
+
+/* Range mask
+ * bits check
+ */
+
+.LBL_RANGEMASK_CHECK:
+        btl       %r12d, %r13d
+
+/* Call scalar math function */
+        jc        .LBL_SCALAR_MATH_CALL
+                                # LOE rbx r15 r12d r13d
+
+/* Special inputs
+ * processing loop
+ */
+
+.LBL_SPECIAL_VALUES_LOOP:
+        incl      %r12d
+        cmpl      $32, %r12d
+
+/* Check bits in range mask */
+        jl        .LBL_RANGEMASK_CHECK
+                                # LOE rbx r15 r12d r13d
+
+        movq      16(%rsp), %r12
+        .cfi_restore 12
+        movq      8(%rsp), %r13
+        .cfi_restore 13
+        movq      (%rsp), %r14
+        .cfi_restore 14
+        vmovups   192(%rsp), %zmm1
+
+/* Go to exit */
+        jmp       .LBL_EXIT
+        /*  DW_CFA_expression: r12 (r12) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -240; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0c, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x10, 0xff, 0xff, 0xff, 0x22
+        /*  DW_CFA_expression: r13 (r13) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -248; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0d, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x08, 0xff, 0xff, 0xff, 0x22
+        /*  DW_CFA_expression: r14 (r14) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -256; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0e, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x00, 0xff, 0xff, 0xff, 0x22
+                                # LOE rbx r12 r13 r14 r15 zmm1
+
+/* Scalar math fucntion call
+ * to process special input
+ */
+
+.LBL_SCALAR_MATH_CALL:
+        movl      %r12d, %r14d
+        vmovsh    64(%rsp,%r14,2), %xmm1
+        vmovsh    128(%rsp,%r14,2), %xmm2
+        vcvtsh2ss %xmm1, %xmm1, %xmm0
+        vcvtsh2ss %xmm2, %xmm2, %xmm1
+        vzeroupper
+        call      atan2f@PLT
+                                # LOE rbx r14 r15 r12d r13d xmm0
+
+        vmovaps   %xmm0, %xmm1
+        vxorps    %xmm0, %xmm0, %xmm0
+        vmovss    %xmm1, %xmm0, %xmm2
+        vcvtss2sh %xmm2, %xmm2, %xmm3
+        vmovsh    %xmm3, 192(%rsp,%r14,2)
+
+/* Process special inputs in loop */
+        jmp       .LBL_SPECIAL_VALUES_LOOP
+                                # LOE rbx r15 r12d r13d
+        .cfi_endproc
+
+        .type	__svml_atan2s32,@function
+        .size	__svml_atan2s32,.-__svml_atan2s32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hatan2_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x4248
+	.endr
+	.rept	32
+        .word	0x3e48
+	.endr
+	.rept	32
+        .word	0x8000
+	.endr
+	.rept	32
+        .word	0xa528
+	.endr
+	.rept	32
+        .word	0x3248
+	.endr
+	.rept	32
+        .word	0xb65d
+	.endr
+	.rept	32
+        .word	0x1f7a
+	.endr
+        .type	__svml_hatan2_data_internal,@object
+        .size	__svml_hatan2_data_internal,576

--- a/linux/avx512/svml_z0_atan2_h_la.s
+++ b/linux/avx512/svml_z0_atan2_h_la.s
@@ -250,3 +250,4 @@ __svml_hatan2_data_internal:
 	.endr
         .type	__svml_hatan2_data_internal,@object
         .size	__svml_hatan2_data_internal,576
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan_h_la.s
+++ b/linux/avx512/svml_z0_atan_h_la.s
@@ -23,29 +23,51 @@
 __svml_atans32:
 
         .cfi_startproc
-
+        kxnord  %k7, %k7, %k7
+        vmovdqu16 __svml_hatan_data_internal(%rip), %zmm30
         vmovdqu16 64+__svml_hatan_data_internal(%rip), %zmm5
-
-/* polynomial */
-        vmovdqu16 320+__svml_hatan_data_internal(%rip), %zmm9
+        vmovdqu16 128+__svml_hatan_data_internal(%rip), %zmm31
+        vmovdqu16 192+__svml_hatan_data_internal(%rip), %zmm1
+        vmovdqu16 256+__svml_hatan_data_internal(%rip), %zmm28
+        vmovdqu16 320+__svml_hatan_data_internal(%rip), %zmm29
         vmovdqu16 384+__svml_hatan_data_internal(%rip), %zmm2
         vmovdqu16 448+__svml_hatan_data_internal(%rip), %zmm3
         vmovdqu16 512+__svml_hatan_data_internal(%rip), %zmm4
 
-/* y=RCP(xa) */
-        vmovdqu16 192+__svml_hatan_data_internal(%rip), %zmm1
+/* npy_half* in -> %rdi, npy_half* out -> %rsi, size_t N -> %rdx */
+.looparray_atan_h:
+        cmpq    $31, %rdx
+        ja .loaddata_atanh
+/* set up mask %k7 for masked load instruction */
+        movl    $1, %eax
+        movl    %edx, %ecx
+        sall    %cl, %eax
+        subl    $1, %eax
+        kmovd   %eax, %k7
+/* Constant required for masked load */
+        movl    $15360, %eax
+        vpbroadcastw    %eax, %zmm0
+        vmovdqu16 (%rdi), %zmm0{%k7}
+        jmp .funcbegin_atan_h
+.loaddata_atanh:
+        vmovdqu16 (%rdi), %zmm0
+        addq $64, %rdi
+        
+.funcbegin_atan_h:
+
+        vmovdqu16 %zmm29, %zmm9
 
 /*
  * No callout
  * xa = |x|
  */
-        vpandd    __svml_hatan_data_internal(%rip), %zmm0, %zmm7
+        vpandd %zmm30, %zmm0, %zmm7
 
 /* SelMask=1 for |x|>1.0 */
         vcmpph    $22, {sae}, %zmm5, %zmm7, %k1
 
 /* High = Pi/2 for |x|>1, 0 otherwise */
-        vpblendmw 128+__svml_hatan_data_internal(%rip), %zmm1, %zmm8{%k1}
+        vpblendmw %zmm31, %zmm1, %zmm8{%k1}
 
 /* sign(x) */
         vpxord    %zmm0, %zmm7, %zmm10
@@ -60,7 +82,7 @@ __svml_atans32:
         vfmadd213ph {rn-sae}, %zmm5, %zmm7, %zmm9
 
 /* change sign of xa, for |x|>1 */
-        vpxord    256+__svml_hatan_data_internal(%rip), %zmm7, %zmm6
+        vpxord %zmm28, %zmm7, %zmm6
         vmovdqu16 %zmm6, %zmm7{%k1}
 
 /* High + xa*Poly */
@@ -68,6 +90,12 @@ __svml_atans32:
 
 /* set sign */
         vpxord    %zmm10, %zmm9, %zmm0
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray_atan_h
         ret
 
         .cfi_endproc

--- a/linux/avx512/svml_z0_atan_h_la.s
+++ b/linux/avx512/svml_z0_atan_h_la.s
@@ -136,3 +136,4 @@ __svml_hatan_data_internal:
 	.endr
         .type	__svml_hatan_data_internal,@object
         .size	__svml_hatan_data_internal,576
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_atan_h_la.s
+++ b/linux/avx512/svml_z0_atan_h_la.s
@@ -45,7 +45,7 @@ __svml_atans32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_atan_h

--- a/linux/avx512/svml_z0_atan_h_la.s
+++ b/linux/avx512/svml_z0_atan_h_la.s
@@ -1,0 +1,110 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Absolute argument and sign: xa = |x|, sign(x)
+ *   Selection mask: SelMask=1 for |x|>1.0
+ *   Reciprocal:  y=RCP(xa)
+ *   xa=y for |x|>1
+ *   High = Pi/2 for |x|>1, 0 otherwise
+ *   Result: High + xa*Poly
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_atans32
+
+__svml_atans32:
+
+        .cfi_startproc
+
+        vmovdqu16 64+__svml_hatan_data_internal(%rip), %zmm5
+
+/* polynomial */
+        vmovdqu16 320+__svml_hatan_data_internal(%rip), %zmm9
+        vmovdqu16 384+__svml_hatan_data_internal(%rip), %zmm2
+        vmovdqu16 448+__svml_hatan_data_internal(%rip), %zmm3
+        vmovdqu16 512+__svml_hatan_data_internal(%rip), %zmm4
+
+/* y=RCP(xa) */
+        vmovdqu16 192+__svml_hatan_data_internal(%rip), %zmm1
+
+/*
+ * No callout
+ * xa = |x|
+ */
+        vpandd    __svml_hatan_data_internal(%rip), %zmm0, %zmm7
+
+/* SelMask=1 for |x|>1.0 */
+        vcmpph    $22, {sae}, %zmm5, %zmm7, %k1
+
+/* High = Pi/2 for |x|>1, 0 otherwise */
+        vpblendmw 128+__svml_hatan_data_internal(%rip), %zmm1, %zmm8{%k1}
+
+/* sign(x) */
+        vpxord    %zmm0, %zmm7, %zmm10
+
+/* xa=y for |x|>1 */
+        vrcpph    %zmm7, %zmm7{%k1}
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm2, %zmm7, %zmm9
+        vfmadd213ph {rn-sae}, %zmm3, %zmm7, %zmm9
+        vfmadd213ph {rn-sae}, %zmm4, %zmm7, %zmm9
+        vfmadd213ph {rn-sae}, %zmm5, %zmm7, %zmm9
+
+/* change sign of xa, for |x|>1 */
+        vpxord    256+__svml_hatan_data_internal(%rip), %zmm7, %zmm6
+        vmovdqu16 %zmm6, %zmm7{%k1}
+
+/* High + xa*Poly */
+        vfmadd213ph {rn-sae}, %zmm8, %zmm7, %zmm9
+
+/* set sign */
+        vpxord    %zmm10, %zmm9, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_atans32,@function
+        .size	__svml_atans32,.-__svml_atans32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hatan_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x3e48
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+	.rept	32
+        .word	0x8000
+	.endr
+	.rept	32
+        .word	0xa528
+	.endr
+	.rept	32
+        .word	0x3248
+	.endr
+	.rept	32
+        .word	0xb65d
+	.endr
+	.rept	32
+        .word	0x1f7a
+	.endr
+        .type	__svml_hatan_data_internal,@object
+        .size	__svml_hatan_data_internal,576

--- a/linux/avx512/svml_z0_atanh_h_la.s
+++ b/linux/avx512/svml_z0_atanh_h_la.s
@@ -44,7 +44,7 @@ __svml_atanhs32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_atanh_h

--- a/linux/avx512/svml_z0_atanh_h_la.s
+++ b/linux/avx512/svml_z0_atanh_h_la.s
@@ -1,0 +1,160 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Compute atanh(x) as 0.5 * log((1 + x)/(1 - x))
+ *
+ *   Special cases:
+ *
+ *   atanh(0)  = 0
+ *   atanh(+1) = +INF
+ *   atanh(-1) = -INF
+ *   atanh(x)  = NaN if |x| > 1, or if x is a NaN or INF
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_atanhs32
+
+__svml_atanhs32:
+
+        .cfi_startproc
+
+/* xa = |x| */
+        vmovdqu16 192+__svml_hatanh_data_internal(%rip), %zmm1
+
+/*
+ * reduced argument: 4*(1-|x|)
+ * scaling by 4 to get around limited FP16 range for coefficient representation
+ */
+        vmovdqu16 256+__svml_hatanh_data_internal(%rip), %zmm3
+
+/* prepare special case mask */
+        vmovdqu16 320+__svml_hatanh_data_internal(%rip), %zmm9
+        vpandd    %zmm1, %zmm0, %zmm2
+        vfnmadd213ph {rn-sae}, %zmm3, %zmm2, %zmm3
+
+/* get table index */
+        vpsrlw    $9, %zmm3, %zmm4
+
+/* Special result */
+        vrsqrtph  %zmm3, %zmm7
+        vcmpph    $18, {sae}, %zmm9, %zmm3, %k1
+
+/* look up poly coefficients: c1, c2, c3 */
+        vpermw    128+__svml_hatanh_data_internal(%rip), %zmm4, %zmm10
+        vpermw    64+__svml_hatanh_data_internal(%rip), %zmm4, %zmm5
+        vpermw    __svml_hatanh_data_internal(%rip), %zmm4, %zmm6
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm5, %zmm3, %zmm10
+        vfmadd213ph {rn-sae}, %zmm6, %zmm3, %zmm10
+
+/* x+x*Poly */
+        vfmadd213ph {rn-sae}, %zmm0, %zmm0, %zmm10
+        vpandnd   %zmm0, %zmm1, %zmm8
+        vpord     %zmm8, %zmm7, %zmm11
+        vpblendmw %zmm11, %zmm10, %zmm0{%k1}
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_atanhs32,@function
+        .size	__svml_atanhs32,.-__svml_atanhs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hatanh_data_internal:
+        .word	0x3770
+        .word	0x35ab
+	.rept	10
+        .word	0x0000
+	.endr
+        .word	0x439e
+        .word	0x4345
+        .word	0x42ed
+        .word	0x4294
+        .word	0x423c
+        .word	0x41e3
+        .word	0x418a
+        .word	0x4132
+        .word	0x40da
+        .word	0x4081
+        .word	0x4029
+        .word	0x3fa2
+        .word	0x3ef4
+        .word	0x3e46
+        .word	0x3d9a
+        .word	0x3cef
+        .word	0x3c48
+        .word	0x3b47
+        .word	0x3a08
+        .word	0x38d4
+        .word	0xb412
+        .word	0xb1b1
+	.rept	10
+        .word	0x0000
+	.endr
+        .word	0xde80
+        .word	0xdc99
+        .word	0xda7d
+        .word	0xd896
+        .word	0xd677
+        .word	0xd491
+        .word	0xd26e
+        .word	0xd088
+        .word	0xce5d
+        .word	0xcc79
+        .word	0xca41
+        .word	0xc85f
+        .word	0xc613
+        .word	0xc437
+        .word	0xc1cc
+        .word	0xbff0
+        .word	0xbd60
+        .word	0xbb38
+        .word	0xb8c7
+        .word	0xb641
+        .word	0x288f
+        .word	0x25b7
+	.rept	10
+        .word	0x0000
+	.endr
+        .word	0x7940
+        .word	0x754a
+        .word	0x713f
+        .word	0x6d49
+        .word	0x693d
+        .word	0x6546
+        .word	0x613a
+        .word	0x5d42
+        .word	0x5934
+        .word	0x553a
+        .word	0x5129
+        .word	0x4d2b
+        .word	0x4915
+        .word	0x4510
+        .word	0x40f3
+        .word	0x3ce4
+        .word	0x38bd
+        .word	0x34a5
+        .word	0x307b
+        .word	0x2c6f
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x4400
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+        .type	__svml_hatanh_data_internal,@object
+        .size	__svml_hatanh_data_internal,384

--- a/linux/avx512/svml_z0_atanh_h_la.s
+++ b/linux/avx512/svml_z0_atanh_h_la.s
@@ -188,3 +188,4 @@ __svml_hatanh_data_internal:
 	.endr
         .type	__svml_hatanh_data_internal,@object
         .size	__svml_hatanh_data_internal,384
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cbrt_h_la.s
+++ b/linux/avx512/svml_z0_cbrt_h_la.s
@@ -1,0 +1,141 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *     x=2^{3*k+j} * 1.b1 b2 ... b5 b6 ... b52
+ *     Let r=(x*2^{-3k-j} - 1.b1 b2 ... b5 1)* rcp[b1 b2 ..b5],
+ *     where rcp[b1 b2 .. b5]=1/(1.b1 b2 b3 b4 b5 1) in single precision
+ *     cbrtf(2^j * 1. b1 b2 .. b5 1) is approximated as T[j][b1..b5]+D[j][b1..b5]
+ *     (T stores the high 24 bits, D stores the low order bits)
+ *     Result=2^k*T+(2^k*T*r)*P+2^k*D
+ *      where P=p1+p2*r+..
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_cbrts32
+
+__svml_cbrts32:
+
+        .cfi_startproc
+
+/* reduced argument R = mantissa - 1 */
+        vmovdqu16 128+__svml_hcbrt_data_internal(%rip), %zmm2
+
+/* polynomial ~ cbrt(mantissa) */
+        vmovdqu16 320+__svml_hcbrt_data_internal(%rip), %zmm10
+        vmovdqu16 384+__svml_hcbrt_data_internal(%rip), %zmm8
+        vmovdqu16 448+__svml_hcbrt_data_internal(%rip), %zmm9
+
+/* will use exponent % 64 as table index */
+        vmovdqu16 256+__svml_hcbrt_data_internal(%rip), %zmm4
+
+/* 2^(expon/3)*2^(expon%3) */
+        vmovdqu16 __svml_hcbrt_data_internal(%rip), %zmm6
+        vgetexpph {sae}, %zmm0, %zmm3
+
+/* mantissa(|x|) */
+        vgetmantph $4, {sae}, %zmm0, %zmm1
+
+/* check for +/-Inf, +/-0 */
+        vfpclassph $30, %zmm0, %k1
+        vaddph    {rn-sae}, %zmm4, %zmm3, %zmm5
+        vsubph    {rn-sae}, %zmm2, %zmm1, %zmm11
+        vpermt2w  64+__svml_hcbrt_data_internal(%rip), %zmm5, %zmm6
+        vfmadd213ph {rn-sae}, %zmm8, %zmm11, %zmm10
+        vfmadd213ph {rn-sae}, %zmm9, %zmm11, %zmm10
+        vmulph    {rn-sae}, %zmm11, %zmm10, %zmm12
+
+/*
+ * No callout
+ * sign
+ */
+        vpandd    192+__svml_hcbrt_data_internal(%rip), %zmm0, %zmm7
+
+/* add sign */
+        vpord     %zmm7, %zmm6, %zmm13
+        vfmadd231ph {rn-sae}, %zmm13, %zmm12, %zmm13
+
+/* fixup for +/-Inf, +/-0 */
+        vmovdqu16 %zmm0, %zmm13{%k1}
+        vmovaps   %zmm13, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_cbrts32,@function
+        .size	__svml_cbrts32,.-__svml_cbrts32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hcbrt_data_internal:
+        .word	0x3c00
+        .word	0x3d0a
+        .word	0x3e59
+        .word	0x4000
+        .word	0x410a
+        .word	0x4259
+        .word	0x4400
+        .word	0x450a
+        .word	0x4659
+        .word	0x4800
+        .word	0x490a
+        .word	0x4a59
+        .word	0x4c00
+        .word	0x4d0a
+        .word	0x4e59
+        .word	0x5000
+	.rept	24
+        .word	0x0000
+	.endr
+        .word	0x1c00
+        .word	0x1d0a
+        .word	0x1e59
+        .word	0x2000
+        .word	0x210a
+        .word	0x2259
+        .word	0x2400
+        .word	0x250a
+        .word	0x2659
+        .word	0x2800
+        .word	0x290a
+        .word	0x2a59
+        .word	0x2c00
+        .word	0x2d0a
+        .word	0x2e59
+        .word	0x3000
+        .word	0x310a
+        .word	0x3259
+        .word	0x3400
+        .word	0x350a
+        .word	0x3659
+        .word	0x3800
+        .word	0x390a
+        .word	0x3a59
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x8000
+	.endr
+	.rept	32
+        .word	0x6600
+	.endr
+	.rept	32
+        .word	0x277c
+	.endr
+	.rept	32
+        .word	0xae84
+	.endr
+	.rept	32
+        .word	0x3554
+	.endr
+        .type	__svml_hcbrt_data_internal,@object
+        .size	__svml_hcbrt_data_internal,512

--- a/linux/avx512/svml_z0_cbrt_h_la.s
+++ b/linux/avx512/svml_z0_cbrt_h_la.s
@@ -45,7 +45,7 @@ __svml_cbrts32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_cbrt_h

--- a/linux/avx512/svml_z0_cbrt_h_la.s
+++ b/linux/avx512/svml_z0_cbrt_h_la.s
@@ -163,3 +163,4 @@ __svml_hcbrt_data_internal:
 	.endr
         .type	__svml_hcbrt_data_internal,@object
         .size	__svml_hcbrt_data_internal,512
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cos_h_la.s
+++ b/linux/avx512/svml_z0_cos_h_la.s
@@ -1,0 +1,247 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *  1) Range reduction to [-Pi/2; +Pi/2] interval
+ *     a) We remove sign using AND operation
+ *     b) Add Pi/2 value to argument X for Cos to Sin transformation
+ *     c) Getting octant Y by 1/Pi multiplication
+ *     d) Add "Right Shifter" value
+ *     e) Treat obtained value as integer for destination sign setting.
+ *        Shift first bit of this value to the last (sign) position
+ *     f) Subtract "Right Shifter"  value
+ *     g) Subtract 0.5 from result for octant correction
+ *     h) Subtract Y*PI from X argument, where PI divided to 4 parts:
+ *        X = X - Y*PI1 - Y*PI2 - Y*PI3 - Y*PI4;
+ *  2) Polynomial (minimax for sin within [-Pi/2; +Pi/2] interval)
+ *     a) Calculate X^2 = X * X
+ *     b) Calculate polynomial:
+ *        R = X + X * X^2 * (A3 + x^2 * (A5 +
+ *  3) Destination sign setting
+ *     a) Set shifted destination sign using XOR operation:
+ *        R = XOR( R, S );
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_coss32
+
+__svml_coss32:
+
+        .cfi_startproc
+
+/* cos(a) = sin(|a|+pi/2) */
+        vmovdqu16 128+__svml_hcos_data_internal(%rip), %zmm2
+        vmovdqu16 192+__svml_hcos_data_internal(%rip), %zmm4
+        vmovdqu16 256+__svml_hcos_data_internal(%rip), %zmm3
+        vmovdqu16 320+__svml_hcos_data_internal(%rip), %zmm6
+
+/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi */
+        vmovdqu16 384+__svml_hcos_data_internal(%rip), %zmm8
+        vmovdqu16 448+__svml_hcos_data_internal(%rip), %zmm7
+
+/* (hR2*c4 + c3)*hR2 + c2 */
+        vmovdqu16 576+__svml_hcos_data_internal(%rip), %zmm12
+        vmovdqu16 640+__svml_hcos_data_internal(%rip), %zmm15
+        vmovdqu16 704+__svml_hcos_data_internal(%rip), %zmm13
+
+/*
+ * Variables:
+ * H
+ * S
+ * HM
+ * No callout
+ * Copy argument
+ */
+        vpandd    __svml_hcos_data_internal(%rip), %zmm0, %zmm1
+        vaddph    {rn-sae}, %zmm2, %zmm1, %zmm9
+
+/* |sX| > threshold? */
+        vpcmpgtw  64+__svml_hcos_data_internal(%rip), %zmm1, %k1
+        vfmadd213ph {rn-sae}, %zmm4, %zmm3, %zmm9
+
+/* fN0 = (int)(sX/pi)*(2^(-5)) */
+        vsubph    {rn-sae}, %zmm4, %zmm9, %zmm5
+
+/*
+ * sign bit, will treat hY as integer value to look at last bit
+ * shift to FP16 sign position
+ */
+        vpsllw    $15, %zmm9, %zmm11
+
+/* hN = ((int)(sX/pi)-0.5)*(2^(-5)) */
+        vsubph    {rn-sae}, %zmm6, %zmm5, %zmm10
+        vfmadd213ph {rn-sae}, %zmm1, %zmm10, %zmm8
+        vfmadd213ph {rn-sae}, %zmm8, %zmm7, %zmm10
+
+/* hR*hR */
+        vmulph    {rn-sae}, %zmm10, %zmm10, %zmm14
+        vfmadd231ph {rn-sae}, %zmm14, %zmm12, %zmm15
+        vfmadd213ph {rn-sae}, %zmm13, %zmm14, %zmm15
+
+/* short path */
+        kortestd  %k1, %k1
+
+/* set sign of R */
+        vpxord    %zmm11, %zmm10, %zmm2
+
+/* hR2*hR */
+        vmulph    {rn-sae}, %zmm2, %zmm14, %zmm0
+
+/* hR + hR3*fPoly */
+        vfmadd213ph {rn-sae}, %zmm2, %zmm15, %zmm0
+
+/* Go to exit */
+        jne       .LBL_EXIT
+                                # LOE rbx rbp r12 r13 r14 r15 zmm0 zmm1 k1
+
+        ret
+
+/* Restore registers
+ * and exit the function
+ */
+
+.LBL_EXIT:
+        vmovups   768+__svml_hcos_data_internal(%rip), %zmm4
+
+/* sRShifter + sX*(1/pi) will round to sRShifter+N, where N=(int)(sX/pi) */
+        vmovups   896+__svml_hcos_data_internal(%rip), %zmm5
+
+/* sN + 0.5 = (int)(sX/pi) = sY - (Rshifter-0.5) */
+        vmovups   832+__svml_hcos_data_internal(%rip), %zmm6
+
+/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi */
+        vmovups   960+__svml_hcos_data_internal(%rip), %zmm7
+        vmovups   1024+__svml_hcos_data_internal(%rip), %zmm9
+        vmovups   1152+__svml_hcos_data_internal(%rip), %zmm12
+        vmovaps   %zmm4, %zmm11
+
+/* convert to FP32 */
+        vextractf32x8 $1, %zmm1, %ymm3
+        vcvtph2psx %ymm1, %zmm8
+        vcvtph2psx %ymm3, %zmm10
+        vfmadd231ps {rz-sae}, %zmm8, %zmm5, %zmm11
+        vfmadd231ps {rz-sae}, %zmm10, %zmm5, %zmm4
+        vsubps    {rn-sae}, %zmm6, %zmm11, %zmm2
+        vsubps    {rn-sae}, %zmm6, %zmm4, %zmm1
+
+/* sign bit, will treat sY as integer value to look at last bit */
+        vpslld    $31, %zmm4, %zmm5
+        vpslld    $31, %zmm11, %zmm3
+        vfmsub231ps {rn-sae}, %zmm2, %zmm7, %zmm8
+        vfmsub231ps {rn-sae}, %zmm1, %zmm7, %zmm10
+
+/* c2*sR2 + c1 */
+        vmovups   1088+__svml_hcos_data_internal(%rip), %zmm4
+        vfmadd213ps {rn-sae}, %zmm8, %zmm9, %zmm2
+        vfmadd213ps {rn-sae}, %zmm10, %zmm9, %zmm1
+
+/* sR*sR */
+        vmulps    {rn-sae}, %zmm2, %zmm2, %zmm13
+        vmulps    {rn-sae}, %zmm1, %zmm1, %zmm14
+        vmovaps   %zmm4, %zmm15
+        vfmadd231ps {rn-sae}, %zmm13, %zmm12, %zmm15
+        vfmadd231ps {rn-sae}, %zmm14, %zmm12, %zmm4
+
+/* sR2*sR */
+        vmulps    {rn-sae}, %zmm2, %zmm13, %zmm12
+        vmulps    {rn-sae}, %zmm1, %zmm14, %zmm13
+
+/* sR + sR3*sPoly */
+        vfmadd213ps {rn-sae}, %zmm2, %zmm15, %zmm12
+        vfmadd213ps {rn-sae}, %zmm1, %zmm4, %zmm13
+
+/* add sign bit to result (logical XOR between sPoly and i32_sgn bits) */
+        vxorps    %zmm3, %zmm12, %zmm1
+        vxorps    %zmm5, %zmm13, %zmm6
+        vcvtps2phx %zmm1, %ymm2
+        vcvtps2phx %zmm6, %ymm7
+        vinsertf32x8 $1, %ymm7, %zmm2, %zmm8
+
+/*
+ * ensure results are always exactly the same for common arguments
+ * (return fast path result for common args)
+ */
+        vpblendmw %zmm8, %zmm0, %zmm0{%k1}
+        ret
+                                # LOE rbx rbp r12 r13 r14 r15 zmm0
+        .cfi_endproc
+
+        .type	__svml_coss32,@function
+        .size	__svml_coss32,.-__svml_coss32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hcos_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x4bd9
+	.endr
+	.rept	32
+        .word	0x3e48
+	.endr
+	.rept	32
+        .word	0x5200
+	.endr
+	.rept	32
+        .word	0x2118
+	.endr
+	.rept	32
+        .word	0x2400
+	.endr
+	.rept	32
+        .word	0xd648
+	.endr
+	.rept	32
+        .word	0xa7ed
+	.endr
+	.rept	32
+        .word	0x0001
+	.endr
+	.rept	32
+        .word	0x8a2d
+	.endr
+	.rept	32
+        .word	0x2042
+	.endr
+	.rept	32
+        .word	0xb155
+	.endr
+	.rept	16
+        .long	0x4b000000
+	.endr
+	.rept	16
+        .long	0x4affffff
+	.endr
+	.rept	16
+        .long	0x3ea2f983
+	.endr
+	.rept	16
+        .long	0x40490fdb
+	.endr
+	.rept	16
+        .long	0xb3bbbd2e
+	.endr
+	.rept	16
+        .long	0xbe2a026e
+	.endr
+	.rept	16
+        .long	0x3bf9f9b6
+	.endr
+	.rept	16
+        .long	0x3f000000
+	.endr
+	.rept	16
+        .long	0x3fc90fdb
+	.endr
+        .type	__svml_hcos_data_internal,@object
+        .size	__svml_hcos_data_internal,1344

--- a/linux/avx512/svml_z0_cos_h_la.s
+++ b/linux/avx512/svml_z0_cos_h_la.s
@@ -64,7 +64,7 @@ __svml_coss32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_cos_h

--- a/linux/avx512/svml_z0_cos_h_la.s
+++ b/linux/avx512/svml_z0_cos_h_la.s
@@ -275,3 +275,4 @@ __svml_hcos_data_internal:
 	.endr
         .type	__svml_hcos_data_internal,@object
         .size	__svml_hcos_data_internal,1344
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_cos_h_la.s
+++ b/linux/avx512/svml_z0_cos_h_la.s
@@ -35,21 +35,47 @@
 __svml_coss32:
 
         .cfi_startproc
+        kxnord  %k7, %k7, %k7
+        vmovdqu16 __svml_hcos_data_internal(%rip), %zmm30
+        vmovdqu16 64+__svml_hcos_data_internal(%rip), %zmm29
+        vmovdqu16 128+__svml_hcos_data_internal(%rip), %zmm31
+        vmovdqu16 192+__svml_hcos_data_internal(%rip), %zmm28
+        vmovdqu16 256+__svml_hcos_data_internal(%rip), %zmm27
+        vmovdqu16 320+__svml_hcos_data_internal(%rip), %zmm26
+        vmovdqu16 384+__svml_hcos_data_internal(%rip), %zmm22
+        vmovdqu16 448+__svml_hcos_data_internal(%rip), %zmm25
+        vmovdqu16 576+__svml_hcos_data_internal(%rip), %zmm24
+        vmovdqu16 640+__svml_hcos_data_internal(%rip), %zmm21
+        vmovdqu16 704+__svml_hcos_data_internal(%rip), %zmm23
+        vmovdqu16 768+__svml_hcos_data_internal(%rip), %zmm20
+        vmovdqu16 896+__svml_hcos_data_internal(%rip), %zmm19
+        vmovdqu16 832+__svml_hcos_data_internal(%rip), %zmm18
+        vmovdqu16 960+__svml_hcos_data_internal(%rip), %zmm17
+        vmovdqu16 1024+__svml_hcos_data_internal(%rip), %zmm16
 
-/* cos(a) = sin(|a|+pi/2) */
-        vmovdqu16 128+__svml_hcos_data_internal(%rip), %zmm2
-        vmovdqu16 192+__svml_hcos_data_internal(%rip), %zmm4
-        vmovdqu16 256+__svml_hcos_data_internal(%rip), %zmm3
-        vmovdqu16 320+__svml_hcos_data_internal(%rip), %zmm6
+/* npy_half* in -> %rdi, npy_half* out -> %rsi, size_t N -> %rdx */
+.looparray__cos_h:
+        cmpq    $31, %rdx
+        ja .loaddata__cos_h
+/* set up mask %k7 for masked load instruction */
+        movl    $1, %eax
+        movl    %edx, %ecx
+        sall    %cl, %eax
+        subl    $1, %eax
+        kmovd   %eax, %k7
+/* Constant required for masked load */
+        movl    $15360, %eax
+        vpbroadcastw    %eax, %zmm0
+        vmovdqu16 (%rdi), %zmm0{%k7}
+        jmp .funcbegin_cos_h
+.loaddata__cos_h:
+        vmovdqu16 (%rdi), %zmm0
+        addq $64, %rdi
+        
+.funcbegin_cos_h:
 
-/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi */
-        vmovdqu16 384+__svml_hcos_data_internal(%rip), %zmm8
-        vmovdqu16 448+__svml_hcos_data_internal(%rip), %zmm7
-
-/* (hR2*c4 + c3)*hR2 + c2 */
-        vmovdqu16 576+__svml_hcos_data_internal(%rip), %zmm12
-        vmovdqu16 640+__svml_hcos_data_internal(%rip), %zmm15
-        vmovdqu16 704+__svml_hcos_data_internal(%rip), %zmm13
+        vmovdqu16 %zmm22, %zmm8
+        vmovdqu16 %zmm21, %zmm15
 
 /*
  * Variables:
@@ -59,15 +85,15 @@ __svml_coss32:
  * No callout
  * Copy argument
  */
-        vpandd    __svml_hcos_data_internal(%rip), %zmm0, %zmm1
-        vaddph    {rn-sae}, %zmm2, %zmm1, %zmm9
+        vpandd    %zmm30, %zmm0, %zmm1
+        vaddph    {rn-sae}, %zmm31, %zmm1, %zmm9
 
 /* |sX| > threshold? */
-        vpcmpgtw  64+__svml_hcos_data_internal(%rip), %zmm1, %k1
-        vfmadd213ph {rn-sae}, %zmm4, %zmm3, %zmm9
+        vpcmpgtw  %zmm29, %zmm1, %k1
+        vfmadd213ph {rn-sae}, %zmm28, %zmm27, %zmm9
 
 /* fN0 = (int)(sX/pi)*(2^(-5)) */
-        vsubph    {rn-sae}, %zmm4, %zmm9, %zmm5
+        vsubph    {rn-sae}, %zmm28, %zmm9, %zmm5
 
 /*
  * sign bit, will treat hY as integer value to look at last bit
@@ -76,14 +102,14 @@ __svml_coss32:
         vpsllw    $15, %zmm9, %zmm11
 
 /* hN = ((int)(sX/pi)-0.5)*(2^(-5)) */
-        vsubph    {rn-sae}, %zmm6, %zmm5, %zmm10
+        vsubph    {rn-sae}, %zmm26, %zmm5, %zmm10
         vfmadd213ph {rn-sae}, %zmm1, %zmm10, %zmm8
-        vfmadd213ph {rn-sae}, %zmm8, %zmm7, %zmm10
+        vfmadd213ph {rn-sae}, %zmm8, %zmm25, %zmm10
 
 /* hR*hR */
         vmulph    {rn-sae}, %zmm10, %zmm10, %zmm14
-        vfmadd231ph {rn-sae}, %zmm14, %zmm12, %zmm15
-        vfmadd213ph {rn-sae}, %zmm13, %zmm14, %zmm15
+        vfmadd231ph {rn-sae}, %zmm14, %zmm24, %zmm15
+        vfmadd213ph {rn-sae}, %zmm23, %zmm14, %zmm15
 
 /* short path */
         kortestd  %k1, %k1
@@ -101,6 +127,13 @@ __svml_coss32:
         jne       .LBL_EXIT
                                 # LOE rbx rbp r12 r13 r14 r15 zmm0 zmm1 k1
 
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray__cos_h
+
         ret
 
 /* Restore registers
@@ -108,44 +141,34 @@ __svml_coss32:
  */
 
 .LBL_EXIT:
-        vmovups   768+__svml_hcos_data_internal(%rip), %zmm4
-
-/* sRShifter + sX*(1/pi) will round to sRShifter+N, where N=(int)(sX/pi) */
-        vmovups   896+__svml_hcos_data_internal(%rip), %zmm5
-
-/* sN + 0.5 = (int)(sX/pi) = sY - (Rshifter-0.5) */
-        vmovups   832+__svml_hcos_data_internal(%rip), %zmm6
-
-/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi */
-        vmovups   960+__svml_hcos_data_internal(%rip), %zmm7
-        vmovups   1024+__svml_hcos_data_internal(%rip), %zmm9
-        vmovups   1152+__svml_hcos_data_internal(%rip), %zmm12
-        vmovaps   %zmm4, %zmm11
+        vmovdqu16 %zmm20, %zmm4
+        vmovdqu16   1152+__svml_hcos_data_internal(%rip), %zmm12
+        vmovdqu16   %zmm4, %zmm11
 
 /* convert to FP32 */
         vextractf32x8 $1, %zmm1, %ymm3
         vcvtph2psx %ymm1, %zmm8
         vcvtph2psx %ymm3, %zmm10
-        vfmadd231ps {rz-sae}, %zmm8, %zmm5, %zmm11
-        vfmadd231ps {rz-sae}, %zmm10, %zmm5, %zmm4
-        vsubps    {rn-sae}, %zmm6, %zmm11, %zmm2
-        vsubps    {rn-sae}, %zmm6, %zmm4, %zmm1
+        vfmadd231ps {rz-sae}, %zmm8, %zmm19, %zmm11
+        vfmadd231ps {rz-sae}, %zmm10, %zmm19, %zmm4
+        vsubps    {rn-sae}, %zmm18, %zmm11, %zmm2
+        vsubps    {rn-sae}, %zmm18, %zmm4, %zmm1
 
 /* sign bit, will treat sY as integer value to look at last bit */
         vpslld    $31, %zmm4, %zmm5
         vpslld    $31, %zmm11, %zmm3
-        vfmsub231ps {rn-sae}, %zmm2, %zmm7, %zmm8
-        vfmsub231ps {rn-sae}, %zmm1, %zmm7, %zmm10
+        vfmsub231ps {rn-sae}, %zmm2, %zmm17, %zmm8
+        vfmsub231ps {rn-sae}, %zmm1, %zmm17, %zmm10
 
 /* c2*sR2 + c1 */
-        vmovups   1088+__svml_hcos_data_internal(%rip), %zmm4
-        vfmadd213ps {rn-sae}, %zmm8, %zmm9, %zmm2
-        vfmadd213ps {rn-sae}, %zmm10, %zmm9, %zmm1
+        vmovdqu16   1088+__svml_hcos_data_internal(%rip), %zmm4
+        vfmadd213ps {rn-sae}, %zmm8, %zmm16, %zmm2
+        vfmadd213ps {rn-sae}, %zmm10, %zmm16, %zmm1
 
 /* sR*sR */
         vmulps    {rn-sae}, %zmm2, %zmm2, %zmm13
         vmulps    {rn-sae}, %zmm1, %zmm1, %zmm14
-        vmovaps   %zmm4, %zmm15
+        vmovdqu16   %zmm4, %zmm15
         vfmadd231ps {rn-sae}, %zmm13, %zmm12, %zmm15
         vfmadd231ps {rn-sae}, %zmm14, %zmm12, %zmm4
 
@@ -169,6 +192,13 @@ __svml_coss32:
  * (return fast path result for common args)
  */
         vpblendmw %zmm8, %zmm0, %zmm0{%k1}
+
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray__cos_h
         ret
                                 # LOE rbx rbp r12 r13 r14 r15 zmm0
         .cfi_endproc

--- a/linux/avx512/svml_z0_cosh_h_la.s
+++ b/linux/avx512/svml_z0_cosh_h_la.s
@@ -50,7 +50,7 @@ __svml_coshs32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_cosh_h

--- a/linux/avx512/svml_z0_cosh_h_la.s
+++ b/linux/avx512/svml_z0_cosh_h_la.s
@@ -1,0 +1,106 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Compute cosh(x) as (exp(x)+exp(-x))/2,
+ *   where exp is calculated as
+ *   exp(M*ln2 + ln2*(j/2^k) + r) = 2^M * 2^(j/2^k) * exp(r)
+ *
+ *   Special cases:
+ *
+ *   cosh(NaN) = quiet NaN, and raise invalid exception
+ *   cosh(INF) = that INF
+ *   cosh(0)   = 1
+ *   cosh(x) overflows for big x and returns MAXLOG+log(2)
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_coshs32
+
+__svml_coshs32:
+
+        .cfi_startproc
+
+/* Shifter + x*log2(e) */
+        vmovdqu16 64+__svml_hcosh_data_internal(%rip), %zmm1
+        vmovdqu16 128+__svml_hcosh_data_internal(%rip), %zmm2
+
+/* Argument reduction:  x - N*log(2) */
+        vmovdqu16 192+__svml_hcosh_data_internal(%rip), %zmm3
+        vmovdqu16 256+__svml_hcosh_data_internal(%rip), %zmm4
+        vmovdqu16 320+__svml_hcosh_data_internal(%rip), %zmm5
+        vmovdqu16 384+__svml_hcosh_data_internal(%rip), %zmm10
+        vmovdqu16 448+__svml_hcosh_data_internal(%rip), %zmm6
+        vmovdqu16 512+__svml_hcosh_data_internal(%rip), %zmm9
+
+/* poly + 0.25*mpoly ~ (exp(x)+exp(-x))*0.5 */
+        vmovdqu16 576+__svml_hcosh_data_internal(%rip), %zmm12
+        vpandd    __svml_hcosh_data_internal(%rip), %zmm0, %zmm7
+        vfmadd213ph {rz-sae}, %zmm2, %zmm7, %zmm1
+        vsubph    {rn-sae}, %zmm2, %zmm1, %zmm8
+        vfnmadd231ph {rn-sae}, %zmm8, %zmm3, %zmm7
+
+/* hN - 1 */
+        vsubph    {rn-sae}, %zmm9, %zmm8, %zmm11
+        vfnmadd231ph {rn-sae}, %zmm8, %zmm4, %zmm7
+
+/* exp(R) */
+        vfmadd231ph {rn-sae}, %zmm7, %zmm5, %zmm10
+        vfmadd213ph {rn-sae}, %zmm6, %zmm7, %zmm10
+        vfmadd213ph {rn-sae}, %zmm9, %zmm7, %zmm10
+
+/* poly*R+1 */
+        vfmadd213ph {rn-sae}, %zmm9, %zmm7, %zmm10
+        vscalefph {rn-sae}, %zmm11, %zmm10, %zmm13
+        vrcpph    %zmm13, %zmm0
+        vfmadd213ph {rn-sae}, %zmm13, %zmm12, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_coshs32,@function
+        .size	__svml_coshs32,.-__svml_coshs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hcosh_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x3dc5
+	.endr
+	.rept	32
+        .word	0x6600
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+	.rept	32
+        .word	0x8af4
+	.endr
+	.rept	32
+        .word	0x2b17
+	.endr
+	.rept	32
+        .word	0x3122
+	.endr
+	.rept	32
+        .word	0x3802
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x3400
+	.endr
+        .type	__svml_hcosh_data_internal,@object
+        .size	__svml_hcosh_data_internal,640

--- a/linux/avx512/svml_z0_cosh_h_la.s
+++ b/linux/avx512/svml_z0_cosh_h_la.s
@@ -133,3 +133,4 @@ __svml_hcosh_data_internal:
 	.endr
         .type	__svml_hcosh_data_internal,@object
         .size	__svml_hcosh_data_internal,640
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp10_h_la.s
+++ b/linux/avx512/svml_z0_exp10_h_la.s
@@ -120,3 +120,4 @@ __svml_hexp10_data_internal:
 	.endr
         .type	__svml_hexp10_data_internal,@object
         .size	__svml_hexp10_data_internal,640
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp10_h_la.s
+++ b/linux/avx512/svml_z0_exp10_h_la.s
@@ -1,0 +1,122 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   exp10(x)  = 2^x/log10(2) = 2^n * (1 + T[j]) * (1 + P(y))
+ *
+ *   x = m*log10(2)/K + y,  y in [-log10(2)/K..log10(2)/K]
+ *   m = n*K + j,           m,n,j - signed integer, j in [-K/2..K/2]
+ *
+ *   values of 2^j/K are tabulated
+ *
+ *   P(y) is a minimax polynomial approximation of exp10(x)-1
+ *   on small interval [-log10(2)/K..log10(2)/K]
+ *
+ *  Special cases:
+ *
+ *   exp10(NaN)  = NaN
+ *   exp10(+INF) = +INF
+ *   exp10(-INF) = 0
+ *   exp10(x)    = 1 for subnormals
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_exp10s32
+
+__svml_exp10s32:
+
+        .cfi_startproc
+
+/* restrict input range to [-8.0,6.0] */
+        vmovdqu16 64+__svml_hexp10_data_internal(%rip), %zmm1
+        vmovdqu16 __svml_hexp10_data_internal(%rip), %zmm3
+
+/* (2^11*1.5 + bias) + x*log2(e) */
+        vmovdqu16 128+__svml_hexp10_data_internal(%rip), %zmm4
+        vmovdqu16 192+__svml_hexp10_data_internal(%rip), %zmm6
+        vmovdqu16 256+__svml_hexp10_data_internal(%rip), %zmm7
+
+/* polynomial ~ 2^R */
+        vmovdqu16 320+__svml_hexp10_data_internal(%rip), %zmm12
+        vmovdqu16 384+__svml_hexp10_data_internal(%rip), %zmm9
+        vmovdqu16 448+__svml_hexp10_data_internal(%rip), %zmm10
+        vmovdqu16 512+__svml_hexp10_data_internal(%rip), %zmm11
+
+/* fixup for input=NaN */
+        vmovdqu16 576+__svml_hexp10_data_internal(%rip), %zmm14
+        vminph    {sae}, %zmm1, %zmm0, %zmm2
+        vcmpph    $22, {sae}, %zmm14, %zmm0, %k1
+        vmaxph    {sae}, %zmm3, %zmm2, %zmm13
+        vmovaps   %zmm4, %zmm5
+        vfmadd231ph {rn-sae}, %zmm13, %zmm6, %zmm5
+
+/* N = 2*(int)(x*log2(e)/2) */
+        vsubph    {rn-sae}, %zmm4, %zmm5, %zmm8
+
+/* 2^(N/2) */
+        vpsllw    $10, %zmm5, %zmm15
+
+/* reduced arg.: x*log2(e) - N */
+        vfmsub231ph {rn-sae}, %zmm13, %zmm6, %zmm8
+        vpblendmw %zmm0, %zmm15, %zmm0{%k1}
+        vfmadd213ph {rn-sae}, %zmm8, %zmm7, %zmm13
+
+/* start polynomial */
+        vfmadd213ph {rn-sae}, %zmm9, %zmm13, %zmm12
+        vfmadd213ph {rn-sae}, %zmm10, %zmm13, %zmm12
+        vfmadd213ph {rn-sae}, %zmm11, %zmm13, %zmm12
+        vmulph    {rn-sae}, %zmm13, %zmm12, %zmm1
+        vfmadd213ph {rn-sae}, %zmm15, %zmm15, %zmm1
+
+/* result:  (1+poly)*2^(N/2)*2^(N/2) */
+        vmulph    {rn-sae}, %zmm0, %zmm1, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_exp10s32,@function
+        .size	__svml_exp10s32,.-__svml_exp10s32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hexp10_data_internal:
+	.rept	32
+        .word	0xc800
+	.endr
+	.rept	32
+        .word	0x4600
+	.endr
+	.rept	32
+        .word	0x6a0f
+	.endr
+	.rept	32
+        .word	0x42a5
+	.endr
+	.rept	32
+        .word	0x8d88
+	.endr
+	.rept	32
+        .word	0x2110
+	.endr
+	.rept	32
+        .word	0x2b52
+	.endr
+	.rept	32
+        .word	0x33af
+	.endr
+	.rept	32
+        .word	0x398b
+	.endr
+	.rept	32
+        .word	0x7c00
+	.endr
+        .type	__svml_hexp10_data_internal,@object
+        .size	__svml_hexp10_data_internal,640

--- a/linux/avx512/svml_z0_exp2_h_la.s
+++ b/linux/avx512/svml_z0_exp2_h_la.s
@@ -138,3 +138,4 @@ __svml_hexp2_data_internal:
 	.endr
         .type	__svml_hexp2_data_internal,@object
         .size	__svml_hexp2_data_internal,768
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp2_h_la.s
+++ b/linux/avx512/svml_z0_exp2_h_la.s
@@ -59,7 +59,7 @@ __svml_exp2s32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_exp2_h

--- a/linux/avx512/svml_z0_exp2_h_la.s
+++ b/linux/avx512/svml_z0_exp2_h_la.s
@@ -1,0 +1,111 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *     2^X = 2^Xo  x  2^{X-Xo}
+ *     2^X = 2^K  x  2^fo  x  2^{X-Xo}
+ *     2^X = 2^K  x  2^fo  x  2^r
+ *
+ *     2^K  --> Manual scaling
+ *     2^fo --> Table lookup
+ *     r    --> 1 + poly    (r = X - Xo)
+ *
+ *     Xo = K  +  fo
+ *     Xo = K  +  0.x1x2x3x4
+ *
+ *     r = X - Xo
+ *       = Vreduce(X, imm)
+ *       = X - VRndScale(X, imm),    where Xo = VRndScale(X, imm)
+ *
+ *     Rnd(S + X) = S + Xo,    where S is selected as S = 2^19 x 1.5
+ *         S + X = S + floor(X) + 0.x1x2x3x4
+ *     Rnd(S + X) = Rnd(2^19 x 1.5 + X)
+ *     (Note: 2^exp x 1.b1b2b3 ... b23,  2^{exp-23} = 2^-4 for exp=19)
+ *
+ *     exp2(x) =  2^K  x  2^fo  x (1 + poly(r)),   where 2^r = 1 + poly(r)
+ *
+ *     Scale back:
+ *     dest = src1 x 2^floor(src2)
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_exp2s32
+
+__svml_exp2s32:
+
+        .cfi_startproc
+
+/*
+ * No callout
+ * reduce argument to [0, 1), i.e. x-floor(x)
+ */
+        vreduceph $9, {sae}, %zmm0, %zmm3
+        vmovdqu16 __svml_hexp2_data_internal(%rip), %zmm5
+        vmovdqu16 64+__svml_hexp2_data_internal(%rip), %zmm1
+        vmovdqu16 128+__svml_hexp2_data_internal(%rip), %zmm2
+        vmovdqu16 192+__svml_hexp2_data_internal(%rip), %zmm4
+
+/* start polynomial */
+        vfmadd213ph {rn-sae}, %zmm1, %zmm3, %zmm5
+        vfmadd213ph {rn-sae}, %zmm2, %zmm3, %zmm5
+        vfmadd213ph {rn-sae}, %zmm4, %zmm3, %zmm5
+
+/* poly*2^floor(x) */
+        vscalefph {rn-sae}, %zmm0, %zmm5, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_exp2s32,@function
+        .size	__svml_exp2s32,.-__svml_exp2s32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hexp2_data_internal:
+	.rept	32
+        .word	0x2d12
+	.endr
+	.rept	32
+        .word	0x332e
+	.endr
+	.rept	32
+        .word	0x3992
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0xce80
+	.endr
+	.rept	32
+        .word	0x4c00
+	.endr
+	.rept	32
+        .word	0x6a0f
+	.endr
+	.rept	32
+        .word	0x2110
+	.endr
+	.rept	32
+        .word	0x2b52
+	.endr
+	.rept	32
+        .word	0x33af
+	.endr
+	.rept	32
+        .word	0x398b
+	.endr
+	.rept	32
+        .word	0x7c00
+	.endr
+        .type	__svml_hexp2_data_internal,@object
+        .size	__svml_hexp2_data_internal,768

--- a/linux/avx512/svml_z0_exp_h_la.s
+++ b/linux/avx512/svml_z0_exp_h_la.s
@@ -1,0 +1,164 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Typical exp() implementation, except that:
+ *    - tables are small, allowing for fast gathers
+ *    - all arguments processed in the main path
+ *        - final VSCALEF assists branch-free design (correct overflow/underflow and special case responses)
+ *        - a VAND is used to ensure the reduced argument |R|<2, even for large inputs
+ *        - RZ mode used to avoid oveflow to +/-Inf for x*log2(e); helps with special case handling
+ *        - SAE used to avoid spurious flag settings
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_exps32
+
+__svml_exps32:
+
+        .cfi_startproc
+
+/* Adjust shifter */
+        vmovdqu16 64+__svml_hexp_data_internal(%rip), %zmm2
+
+/* Shifter + x*log2(e) */
+        vmovdqu16 128+__svml_hexp_data_internal(%rip), %zmm5
+
+/* Argument reduction:  x - N*log(2) */
+        vmovdqu16 192+__svml_hexp_data_internal(%rip), %zmm3
+        vmovdqu16 256+__svml_hexp_data_internal(%rip), %zmm4
+
+/*
+ * Variables:
+ * W
+ * H
+ * HM
+ * No callout
+ * Copy argument
+ * Check sign of input (to adjust shifter)
+ */
+        vpxord    %zmm1, %zmm1, %zmm1
+        vpcmpgtw  %zmm1, %zmm0, %k1
+        vpsubw    __svml_hexp_data_internal(%rip), %zmm2, %zmm2{%k1}
+        vfmadd213ph {rz-sae}, %zmm2, %zmm0, %zmm5
+        vsubph    {rn-sae}, %zmm2, %zmm5, %zmm8
+
+/*
+ * 2^(k/32) (k in 0..31)
+ * table value: index in last 5 bits of S
+ */
+        vpermw    320+__svml_hexp_data_internal(%rip), %zmm5, %zmm6
+        vfmadd231ph {rn-sae}, %zmm8, %zmm3, %zmm0
+        vfmadd231ph {rn-sae}, %zmm8, %zmm4, %zmm0
+
+/* T+T*R */
+        vfmadd213ph {rn-sae}, %zmm6, %zmm0, %zmm6
+
+/* Fixup for sign of underflow result */
+        vpandd    448+__svml_hexp_data_internal(%rip), %zmm6, %zmm7
+
+/* (T+T*R)*2^floor(N) */
+        vscalefph {rn-sae}, %zmm8, %zmm7, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_exps32,@function
+        .size	__svml_exps32,.-__svml_exps32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hexp_data_internal:
+	.rept	32
+        .word	0x0100
+	.endr
+	.rept	32
+        .word	0x5300
+	.endr
+	.rept	32
+        .word	0x3dc5
+	.endr
+	.rept	32
+        .word	0xb98c
+	.endr
+	.rept	32
+        .word	0x0af4
+	.endr
+        .word	0x3c00
+        .word	0x3c16
+        .word	0x3c2d
+        .word	0x3c45
+        .word	0x3c5d
+        .word	0x3c75
+        .word	0x3c8e
+        .word	0x3ca8
+        .word	0x3cc2
+        .word	0x3cdc
+        .word	0x3cf8
+        .word	0x3d14
+        .word	0x3d30
+        .word	0x3d4d
+        .word	0x3d6b
+        .word	0x3d89
+        .word	0x3da8
+        .word	0x3dc8
+        .word	0x3de8
+        .word	0x3e09
+        .word	0x3e2b
+        .word	0x3e4e
+        .word	0x3e71
+        .word	0x3e95
+        .word	0x3eba
+        .word	0x3ee0
+        .word	0x3f06
+        .word	0x3f2e
+        .word	0x3f56
+        .word	0x3f7f
+        .word	0x3fa9
+        .word	0x3fd4
+	.rept	32
+        .word	0xbfff
+	.endr
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0xcc80
+	.endr
+	.rept	32
+        .word	0x4a00
+	.endr
+	.rept	32
+        .word	0x6a0f
+	.endr
+	.rept	32
+        .word	0x3dc5
+	.endr
+	.rept	32
+        .word	0x0d1e
+	.endr
+	.rept	32
+        .word	0x2110
+	.endr
+	.rept	32
+        .word	0x2b52
+	.endr
+	.rept	32
+        .word	0x33af
+	.endr
+	.rept	32
+        .word	0x398b
+	.endr
+	.rept	32
+        .word	0x7c00
+	.endr
+        .type	__svml_hexp_data_internal,@object
+        .size	__svml_hexp_data_internal,1152

--- a/linux/avx512/svml_z0_exp_h_la.s
+++ b/linux/avx512/svml_z0_exp_h_la.s
@@ -191,3 +191,4 @@ __svml_hexp_data_internal:
 	.endr
         .type	__svml_hexp_data_internal,@object
         .size	__svml_hexp_data_internal,1152
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_exp_h_la.s
+++ b/linux/avx512/svml_z0_exp_h_la.s
@@ -45,7 +45,7 @@ __svml_exps32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_exp_h

--- a/linux/avx512/svml_z0_expm1_h_la.s
+++ b/linux/avx512/svml_z0_expm1_h_la.s
@@ -1,0 +1,124 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   After computing exp(x), an accurate computation is performed to obtain exp(x)-1
+ *   Typical exp() implementation, except that:
+ *    - tables are small, allowing for fast gathers
+ *    - all arguments processed in the main path
+ *        - final VSCALEF assists branch-free design (correct overflow/underflow and special case responses)
+ *        - a VAND is used to ensure the reduced argument |R|<2, even for large inputs
+ *        - RZ mode used to avoid oveflow to +/-Inf for x*log2(e); helps with special case handling
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_expm1s32
+
+__svml_expm1s32:
+
+        .cfi_startproc
+
+/* No callout */
+        vmovups   __svml_hexpm1_data_internal(%rip), %zmm2
+        vmovups   64+__svml_hexpm1_data_internal(%rip), %zmm5
+        vmovups   192+__svml_hexpm1_data_internal(%rip), %zmm11
+        vmovups   128+__svml_hexpm1_data_internal(%rip), %zmm6
+        vmovups   256+__svml_hexpm1_data_internal(%rip), %zmm7
+        vmovups   320+__svml_hexpm1_data_internal(%rip), %zmm8
+
+/* 2^N */
+        vmovups   384+__svml_hexpm1_data_internal(%rip), %zmm15
+
+/* polynomial ~ expm1(R)/R */
+        vmovaps   %zmm11, %zmm9
+        vextractf32x8 $1, %zmm0, %ymm1
+        vcvtph2psx %ymm0, %zmm10
+        vcvtph2psx %ymm1, %zmm12
+
+/* Shifter + x * log2(e) */
+        vmulps    {rn-sae}, %zmm2, %zmm10, %zmm3
+        vmulps    {rn-sae}, %zmm2, %zmm12, %zmm4
+
+/* N ~ x*log2(e) */
+        vrndscaleps $8, {sae}, %zmm3, %zmm13
+        vrndscaleps $8, {sae}, %zmm4, %zmm14
+
+/* R = x - N*ln(2)_high */
+        vfmadd231ps {rn-sae}, %zmm13, %zmm5, %zmm10
+        vfmadd231ps {rn-sae}, %zmm14, %zmm5, %zmm12
+        vscalefps {rn-sae}, %zmm13, %zmm15, %zmm13
+        vscalefps {rn-sae}, %zmm14, %zmm15, %zmm14
+        vfmadd231ps {rn-sae}, %zmm10, %zmm6, %zmm9
+        vfmadd231ps {rn-sae}, %zmm12, %zmm6, %zmm11
+
+/* fixup for overflow and special cases */
+        vfpclassps $14, %zmm13, %k0
+        vfpclassps $14, %zmm14, %k2
+
+/* 2^N - 1 */
+        vsubps    {rn-sae}, %zmm15, %zmm13, %zmm2
+        vsubps    {rn-sae}, %zmm15, %zmm14, %zmm4
+        vfmadd213ps {rn-sae}, %zmm7, %zmm10, %zmm9
+        vfmadd213ps {rn-sae}, %zmm7, %zmm12, %zmm11
+        knotw     %k0, %k1
+        knotw     %k2, %k3
+        vfmadd213ps {rn-sae}, %zmm8, %zmm10, %zmm9
+        vfmadd213ps {rn-sae}, %zmm8, %zmm12, %zmm11
+
+/* exp(R) - 1 */
+        vmulps    {rn-sae}, %zmm10, %zmm9, %zmm0
+        vmulps    {rn-sae}, %zmm12, %zmm11, %zmm1
+
+/* result */
+        vfmadd231ps {rn-sae}, %zmm0, %zmm13, %zmm2{%k1}
+        vfmadd231ps {rn-sae}, %zmm1, %zmm14, %zmm4{%k3}
+        vcvtps2phx %zmm2, %ymm3
+        vcvtps2phx %zmm4, %ymm5
+        vinsertf32x8 $1, %ymm5, %zmm3, %zmm0
+
+/*
+ * #else  _LA_, _EP_
+ * #endif  _LA_, _EP_
+ */
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_expm1s32,@function
+        .size	__svml_expm1s32,.-__svml_expm1s32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hexpm1_data_internal:
+	.rept	16
+        .long	0x3fb8aa3b
+	.endr
+	.rept	16
+        .long	0xbf317218
+	.endr
+	.rept	16
+        .long	0x3d2bb1be
+	.endr
+	.rept	16
+        .long	0x3e2bb1c1
+	.endr
+	.rept	16
+        .long	0x3efffeaf
+	.endr
+	.rept	16
+        .long	0x3f7fff03
+	.endr
+	.rept	16
+        .long	0x3f800000
+	.endr
+        .type	__svml_hexpm1_data_internal,@object
+        .size	__svml_hexpm1_data_internal,448

--- a/linux/avx512/svml_z0_expm1_h_la.s
+++ b/linux/avx512/svml_z0_expm1_h_la.s
@@ -151,3 +151,4 @@ __svml_hexpm1_data_internal:
 	.endr
         .type	__svml_hexpm1_data_internal,@object
         .size	__svml_hexpm1_data_internal,448
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_ln_h_la.s
+++ b/linux/avx512/svml_z0_ln_h_la.s
@@ -1,0 +1,184 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *    log(x) = VGETEXP(x)*log(2) + log(VGETMANT(x))
+ *    VGETEXP, VGETMANT will correctly treat special cases too (including denormals)
+ *    mx = VGETMANT(x) is in [1,2) for all x>=0
+ *    log(mx) = -log(RCP(mx)) + log(1 +(mx*RCP(mx)-1))
+ *    and the table lookup for log(RCP(mx))
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_logs32
+
+__svml_logs32:
+
+        .cfi_startproc
+
+/*
+ * Variables:
+ * H
+ * No callout
+ * Copy argument
+ * GetMant(x), normalized to [.75,1.5) for x>=0, NaN for x<0
+ */
+        vgetmantph $11, {sae}, %zmm0, %zmm2
+
+/* Get exponent */
+        vgetexpph {sae}, %zmm0, %zmm4
+
+/* exponent corrrection */
+        vgetexpph {sae}, %zmm2, %zmm5
+
+/* reduced argument */
+        vmovdqu16 __svml_hlog_data_internal(%rip), %zmm1
+
+/* expon*log(2) */
+        vmovdqu16 64+__svml_hlog_data_internal(%rip), %zmm8
+
+/* table index */
+        vpsrlw    $5, %zmm2, %zmm3
+
+/* exponent corrrection */
+        vsubph    {rn-sae}, %zmm5, %zmm4, %zmm7
+        vsubph    {rn-sae}, %zmm1, %zmm2, %zmm0
+
+/* polynomial coefficients */
+        vpermw    128+__svml_hlog_data_internal(%rip), %zmm3, %zmm9
+        vpermw    192+__svml_hlog_data_internal(%rip), %zmm3, %zmm6
+        vmulph    {rn-sae}, %zmm8, %zmm7, %zmm10
+
+/* hC0+hC1*R */
+        vfmadd213ph {rn-sae}, %zmm6, %zmm0, %zmm9
+
+/* result res = R*P + Expon */
+        vfmadd213ph {rn-sae}, %zmm10, %zmm9, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_logs32,@function
+        .size	__svml_logs32,.-__svml_logs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hlog_data_internal:
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+        .word	0xb7d6
+        .word	0xb787
+        .word	0xb73c
+        .word	0xb6f6
+        .word	0xb6b5
+        .word	0xb677
+        .word	0xb63e
+        .word	0xb607
+        .word	0xb5d3
+        .word	0xb5a3
+        .word	0xb575
+        .word	0xb549
+        .word	0xb520
+        .word	0xb4f8
+        .word	0xb4d3
+        .word	0xb4af
+        .word	0xb9c4
+        .word	0xb99d
+        .word	0xb978
+        .word	0xb955
+        .word	0xb933
+        .word	0xb912
+        .word	0xb8f3
+        .word	0xb8d5
+        .word	0xb8b8
+        .word	0xb89c
+        .word	0xb882
+        .word	0xb868
+        .word	0xb850
+        .word	0xb838
+        .word	0xb821
+        .word	0xb80b
+        .word	0x3c00
+        .word	0x3bff
+        .word	0x3bfc
+        .word	0x3bf9
+        .word	0x3bf5
+        .word	0x3bf0
+        .word	0x3beb
+        .word	0x3be5
+        .word	0x3bde
+        .word	0x3bd8
+        .word	0x3bd0
+        .word	0x3bc9
+        .word	0x3bc1
+        .word	0x3bb9
+        .word	0x3bb1
+        .word	0x3ba9
+        .word	0x3bc4
+        .word	0x3bcd
+        .word	0x3bd5
+        .word	0x3bdc
+        .word	0x3be2
+        .word	0x3be8
+        .word	0x3bed
+        .word	0x3bf1
+        .word	0x3bf5
+        .word	0x3bf8
+        .word	0x3bfa
+        .word	0x3bfc
+        .word	0x3bfe
+        .word	0x3bff
+	.rept	2
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x001f
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+	.rept	16
+        .long	0x00000001
+	.endr
+	.rept	16
+        .long	0x0000007f
+	.endr
+	.rept	16
+        .long	0x3f800000
+	.endr
+	.rept	16
+        .long	0x3e51367b
+	.endr
+	.rept	16
+        .long	0xbebfd356
+	.endr
+	.rept	16
+        .long	0x3ef9e953
+	.endr
+	.rept	16
+        .long	0xbf389f48
+	.endr
+	.rept	16
+        .long	0x3fb8a7e4
+	.endr
+	.rept	16
+        .long	0x3f317218
+	.endr
+	.rept	32
+        .word	0xfc00
+	.endr
+        .type	__svml_hlog_data_internal,@object
+        .size	__svml_hlog_data_internal,1024

--- a/linux/avx512/svml_z0_ln_h_la.s
+++ b/linux/avx512/svml_z0_ln_h_la.s
@@ -208,3 +208,4 @@ __svml_hlog_data_internal:
 	.endr
         .type	__svml_hlog_data_internal,@object
         .size	__svml_hlog_data_internal,1024
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log10_h_la.s
+++ b/linux/avx512/svml_z0_log10_h_la.s
@@ -1,0 +1,121 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *    log10(x) = VGETEXP(x)*log10(2) + log10(VGETMANT(x))
+ *    VGETEXP, VGETMANT will correctly treat special cases too (including denormals)
+ *    mx = VGETMANT(x) is in [1,2) for all x>=0
+ *    log10(mx) = -log10(RCP(mx)) + log10(1 +(mx*RCP(mx)-1))
+ *    and the table lookup for log(RCP(mx))
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_log10s32
+
+__svml_log10s32:
+
+        .cfi_startproc
+
+/* reduced argument */
+        vmovdqu16 384+__svml_hlog10_data_internal(%rip), %zmm4
+        vmovdqu16 64+__svml_hlog10_data_internal(%rip), %zmm9
+        vmovdqu16 128+__svml_hlog10_data_internal(%rip), %zmm5
+        vmovdqu16 192+__svml_hlog10_data_internal(%rip), %zmm6
+        vmovdqu16 256+__svml_hlog10_data_internal(%rip), %zmm7
+        vmovdqu16 320+__svml_hlog10_data_internal(%rip), %zmm8
+        vmovdqu16 __svml_hlog10_data_internal(%rip), %zmm11
+
+/* Get exponent */
+        vgetexpph {sae}, %zmm0, %zmm1
+
+/* GetMant(x), normalized to [.75,1.5) for x>=0, NaN for x<0 */
+        vgetmantph $11, {sae}, %zmm0, %zmm3
+        vsubph    {rn-sae}, %zmm4, %zmm3, %zmm10
+
+/* exponent corrrection */
+        vgetexpph {sae}, %zmm3, %zmm2
+        vfmadd213ph {rn-sae}, %zmm5, %zmm10, %zmm9
+        vsubph    {rn-sae}, %zmm2, %zmm1, %zmm0
+        vfmadd213ph {rn-sae}, %zmm6, %zmm10, %zmm9
+        vfmadd213ph {rn-sae}, %zmm7, %zmm10, %zmm9
+        vfmadd213ph {rn-sae}, %zmm8, %zmm10, %zmm9
+        vmulph    {rn-sae}, %zmm10, %zmm9, %zmm12
+        vfmadd213ph {rn-sae}, %zmm12, %zmm11, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_log10s32,@function
+        .size	__svml_log10s32,.-__svml_log10s32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hlog10_data_internal:
+	.rept	32
+        .word	0x34d1
+	.endr
+	.rept	32
+        .word	0x2bad
+	.endr
+	.rept	32
+        .word	0xaf2b
+	.endr
+	.rept	32
+        .word	0x30b4
+	.endr
+	.rept	32
+        .word	0xb2f3
+	.endr
+	.rept	32
+        .word	0x36f3
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x001f
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+	.rept	16
+        .long	0x00000001
+	.endr
+	.rept	16
+        .long	0x0000007f
+	.endr
+	.rept	16
+        .long	0x3f800000
+	.endr
+	.rept	16
+        .long	0x3e51367b
+	.endr
+	.rept	16
+        .long	0xbebfd356
+	.endr
+	.rept	16
+        .long	0x3ef9e953
+	.endr
+	.rept	16
+        .long	0xbf389f48
+	.endr
+	.rept	16
+        .long	0x3fb8a7e4
+	.endr
+	.rept	16
+        .long	0x3e9a209b
+	.endr
+	.rept	32
+        .word	0xfc00
+	.endr
+        .type	__svml_hlog10_data_internal,@object
+        .size	__svml_hlog10_data_internal,1216

--- a/linux/avx512/svml_z0_log10_h_la.s
+++ b/linux/avx512/svml_z0_log10_h_la.s
@@ -148,3 +148,4 @@ __svml_hlog10_data_internal:
 	.endr
         .type	__svml_hlog10_data_internal,@object
         .size	__svml_hlog10_data_internal,1216
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log1p_h_la.s
+++ b/linux/avx512/svml_z0_log1p_h_la.s
@@ -1,0 +1,130 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   log(x) = VGETEXP(x)*log(2) + log(VGETMANT(x))
+ *   VGETEXP, VGETMANT will correctly treat special cases too (including denormals)
+ *   mx = VGETMANT(x) is in [1,2) for all x>=0
+ *   log(mx) = -log(RCP(mx)) + log(1 +(mx*RCP(mx)-1))
+ *   and the table lookup for log(RCP(mx))
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_log1ps32
+
+__svml_log1ps32:
+
+        .cfi_startproc
+
+/* No callout */
+        vmovdqu16 __svml_hlog1p_data_internal(%rip), %zmm6
+        vmovdqu16 192+__svml_hlog1p_data_internal(%rip), %zmm11
+        vmovdqu16 256+__svml_hlog1p_data_internal(%rip), %zmm14
+        vmovdqu16 320+__svml_hlog1p_data_internal(%rip), %zmm15
+
+/* x+1.0 */
+        vaddph    {rn-sae}, %zmm6, %zmm0, %zmm1
+
+/* A = max(x, 1.0) */
+        vmaxph    {sae}, %zmm6, %zmm0, %zmm2
+
+/* B = min(x, 1.0); */
+        vminph    {sae}, %zmm6, %zmm0, %zmm3
+
+/* input is zero or +Inf? */
+        vfpclassph $14, %zmm0, %k1
+
+/* reduce mantissa to [.75, 1.5) */
+        vgetmantph $11, {sae}, %zmm1, %zmm5
+
+/* Bh */
+        vsubph    {rn-sae}, %zmm2, %zmm1, %zmm4
+
+/* exponent */
+        vgetexpph {sae}, %zmm1, %zmm8
+
+/* exponent correction */
+        vgetexpph {sae}, %zmm5, %zmm7
+
+/* Mant_low */
+        vsubph    {rn-sae}, %zmm4, %zmm3, %zmm9
+
+/* reduced argument */
+        vsubph    {rn-sae}, %zmm6, %zmm5, %zmm12
+
+/* -exponent */
+        vsubph    {rn-sae}, %zmm8, %zmm7, %zmm1
+
+/* mant_low, whith proper scale */
+        vscalefph {rn-sae}, %zmm1, %zmm9, %zmm10
+        vmovdqu16 384+__svml_hlog1p_data_internal(%rip), %zmm9
+
+/* fixup in case Mant_low=NaN */
+        vpandd    64+__svml_hlog1p_data_internal(%rip), %zmm10, %zmm13
+        vmovdqu16 128+__svml_hlog1p_data_internal(%rip), %zmm10
+
+/* start polynomial */
+        vfmadd213ph {rn-sae}, %zmm11, %zmm12, %zmm10
+
+/* apply correction to reduced argument */
+        vaddph    {rn-sae}, %zmm13, %zmm12, %zmm11
+        vmovdqu16 448+__svml_hlog1p_data_internal(%rip), %zmm12
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm14, %zmm11, %zmm10
+        vfmadd213ph {rn-sae}, %zmm15, %zmm11, %zmm10
+        vfmadd213ph {rn-sae}, %zmm9, %zmm11, %zmm10
+
+/* Poly*R+R */
+        vfmadd213ph {rn-sae}, %zmm11, %zmm11, %zmm10
+
+/* result:  -m_expon*log(2)+poly */
+        vfnmadd213ph {rn-sae}, %zmm10, %zmm12, %zmm1
+
+/* fixup for +0/-0/+Inf */
+        vpblendmw %zmm0, %zmm1, %zmm0{%k1}
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_log1ps32,@function
+        .size	__svml_log1ps32,.-__svml_log1ps32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hlog1p_data_internal:
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0xbfff
+	.endr
+	.rept	32
+        .word	0x3088
+	.endr
+	.rept	32
+        .word	0xb428
+	.endr
+	.rept	32
+        .word	0x356a
+	.endr
+	.rept	32
+        .word	0xb800
+	.endr
+	.rept	32
+        .word	0x833f
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+        .type	__svml_hlog1p_data_internal,@object
+        .size	__svml_hlog1p_data_internal,512

--- a/linux/avx512/svml_z0_log1p_h_la.s
+++ b/linux/avx512/svml_z0_log1p_h_la.s
@@ -160,3 +160,4 @@ __svml_hlog1p_data_internal:
 	.endr
         .type	__svml_hlog1p_data_internal,@object
         .size	__svml_hlog1p_data_internal,512
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_log1p_h_la.s
+++ b/linux/avx512/svml_z0_log1p_h_la.s
@@ -44,7 +44,7 @@ __svml_log1ps32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_log1p_h

--- a/linux/avx512/svml_z0_log2_h_la.s
+++ b/linux/avx512/svml_z0_log2_h_la.s
@@ -1,0 +1,123 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *    log2(x) = VGETEXP(x) + log2(VGETMANT(x))
+ *    VGETEXP, VGETMANT will correctly treat special cases too (including denormals)
+ *    mx = VGETMANT(x) is in [1,2) for all x>=0
+ *    log2(mx) = -log2(RCP(mx)) + log2(1 +(mx*RCP(mx)-1))
+ *    and the table lookup for log2(RCP(mx))
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_log2s32
+
+__svml_log2s32:
+
+        .cfi_startproc
+
+/* No callout */
+        vmovdqu16 __svml_hlog2_data_internal(%rip), %zmm1
+        vmovdqu16 128+__svml_hlog2_data_internal(%rip), %zmm3
+        vmovdqu16 192+__svml_hlog2_data_internal(%rip), %zmm6
+        vmovdqu16 256+__svml_hlog2_data_internal(%rip), %zmm7
+        vmovdqu16 320+__svml_hlog2_data_internal(%rip), %zmm8
+
+/* exponent */
+        vgetexpph {sae}, %zmm0, %zmm4
+
+/* reduce mantissa to [.75, 1.5) */
+        vgetmantph $11, {sae}, %zmm0, %zmm2
+        vmovdqu16 64+__svml_hlog2_data_internal(%rip), %zmm0
+
+/* reduced argument */
+        vsubph    {rn-sae}, %zmm1, %zmm2, %zmm9
+
+/* exponent correction */
+        vgetexpph {sae}, %zmm2, %zmm5
+
+/* start polynomial */
+        vfmadd213ph {rn-sae}, %zmm3, %zmm9, %zmm0
+
+/* exponent */
+        vsubph    {rn-sae}, %zmm5, %zmm4, %zmm10
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm6, %zmm9, %zmm0
+        vfmadd213ph {rn-sae}, %zmm7, %zmm9, %zmm0
+        vfmadd213ph {rn-sae}, %zmm8, %zmm9, %zmm0
+
+/* Poly*R+expon */
+        vfmadd213ph {rn-sae}, %zmm10, %zmm9, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_log2s32,@function
+        .size	__svml_log2s32,.-__svml_log2s32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hlog2_data_internal:
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x328a
+	.endr
+	.rept	32
+        .word	0xb5ff
+	.endr
+	.rept	32
+        .word	0x37cf
+	.endr
+	.rept	32
+        .word	0xb9c5
+	.endr
+	.rept	32
+        .word	0x3dc5
+	.endr
+	.rept	32
+        .word	0x001f
+	.endr
+	.rept	32
+        .word	0x0000
+	.endr
+	.rept	16
+        .long	0x00000001
+	.endr
+	.rept	16
+        .long	0x0000007f
+	.endr
+	.rept	16
+        .long	0x3f800000
+	.endr
+	.rept	16
+        .long	0x3e51367b
+	.endr
+	.rept	16
+        .long	0xbebfd356
+	.endr
+	.rept	16
+        .long	0x3ef9e953
+	.endr
+	.rept	16
+        .long	0xbf389f48
+	.endr
+	.rept	16
+        .long	0x3fb8a7e4
+	.endr
+	.rept	32
+        .word	0xfc00
+	.endr
+        .type	__svml_hlog2_data_internal,@object
+        .size	__svml_hlog2_data_internal,1088

--- a/linux/avx512/svml_z0_log2_h_la.s
+++ b/linux/avx512/svml_z0_log2_h_la.s
@@ -150,3 +150,4 @@ __svml_hlog2_data_internal:
 	.endr
         .type	__svml_hlog2_data_internal,@object
         .size	__svml_hlog2_data_internal,1088
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_pow_h_la.s
+++ b/linux/avx512/svml_z0_pow_h_la.s
@@ -278,3 +278,4 @@ __svml_hpow_data_internal:
 	.endr
         .type	__svml_hpow_data_internal,@object
         .size	__svml_hpow_data_internal,704
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_pow_h_la.s
+++ b/linux/avx512/svml_z0_pow_h_la.s
@@ -1,0 +1,280 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *    For pow computation sequences for log2() and exp2() are done with small tables
+ *    The log2() part uses VGETEXP/VGETMANT (which treat denormals correctly)
+ *    Branches are not needed for overflow/underflow:
+ *    RZ mode used to prevent overflow to +/-Inf in intermediate computations
+ *    Final VSCALEF properly handles overflow and underflow cases
+ *    Callout is used for Inf/NaNs or x<=0
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_pows32
+
+__svml_pows32:
+
+        .cfi_startproc
+
+        pushq     %rbp
+        .cfi_def_cfa_offset 16
+        movq      %rsp, %rbp
+        .cfi_def_cfa 6, 16
+        .cfi_offset 6, -16
+        andq      $-64, %rsp
+        subq      $256, %rsp
+
+/* x<=0 or Inf/NaN? */
+        vfpclassph $223, %zmm0, %k0
+
+/* y is Inf/NaN? */
+        vfpclassph $153, %zmm1, %k1
+
+/* mx - 1 */
+        vmovups   __svml_hpow_data_internal(%rip), %zmm8
+
+/* log polynomial */
+        vmovups   64+__svml_hpow_data_internal(%rip), %zmm4
+        vmovups   320+__svml_hpow_data_internal(%rip), %zmm7
+        kmovd     %k0, %edx
+        kmovd     %k1, %eax
+
+/* set range mask */
+        orl       %eax, %edx
+        vextractf32x8 $1, %zmm0, %ymm14
+        vcvtph2psx %ymm0, %zmm12
+        vcvtph2psx %ymm14, %zmm10
+
+/* GetMant(x), range [0.75, 1.5) */
+        vgetmantps $11, {sae}, %zmm12, %zmm5
+        vgetmantps $11, {sae}, %zmm10, %zmm6
+
+/* GetExp(x) */
+        vgetexpps {sae}, %zmm12, %zmm13
+        vgetexpps {sae}, %zmm10, %zmm11
+
+/* exponent correction */
+        vgetexpps {sae}, %zmm5, %zmm9
+        vgetexpps {sae}, %zmm6, %zmm3
+        vsubps    {rn-sae}, %zmm8, %zmm5, %zmm12
+        vsubps    {rn-sae}, %zmm8, %zmm6, %zmm10
+
+/* apply exponent correction */
+        vsubps    {rn-sae}, %zmm3, %zmm11, %zmm3
+        vmovups   192+__svml_hpow_data_internal(%rip), %zmm5
+        vmovups   256+__svml_hpow_data_internal(%rip), %zmm6
+        vextractf32x8 $1, %zmm1, %ymm2
+        vcvtph2psx %ymm2, %zmm14
+        vmovups   128+__svml_hpow_data_internal(%rip), %zmm2
+        vmovaps   %zmm2, %zmm8
+        vfmadd231ps {rn-sae}, %zmm12, %zmm4, %zmm8
+        vfmadd231ps {rn-sae}, %zmm10, %zmm4, %zmm2
+        vsubps    {rn-sae}, %zmm9, %zmm13, %zmm4
+
+/* poly */
+        vfmadd213ps {rn-sae}, %zmm5, %zmm12, %zmm8
+        vfmadd213ps {rn-sae}, %zmm5, %zmm10, %zmm2
+        vmovdqu16 512+__svml_hpow_data_internal(%rip), %zmm5
+        vfmadd213ps {rn-sae}, %zmm6, %zmm12, %zmm8
+        vfmadd213ps {rn-sae}, %zmm6, %zmm10, %zmm2
+        vmovdqu16 576+__svml_hpow_data_internal(%rip), %zmm6
+        vfmadd213ps {rn-sae}, %zmm7, %zmm12, %zmm8
+        vfmadd213ps {rn-sae}, %zmm7, %zmm10, %zmm2
+        vmovups   384+__svml_hpow_data_internal(%rip), %zmm7
+        vfmadd213ps {rn-sae}, %zmm7, %zmm12, %zmm8
+        vfmadd213ps {rn-sae}, %zmm7, %zmm10, %zmm2
+
+/* log2(x) */
+        vfmadd213ps {rn-sae}, %zmm4, %zmm12, %zmm8
+        vfmadd213ps {rn-sae}, %zmm3, %zmm10, %zmm2
+
+/* polynomial */
+        vmovdqu16 448+__svml_hpow_data_internal(%rip), %zmm10
+
+/* y*log2(x) */
+        vmulps    {rn-sae}, %zmm2, %zmm14, %zmm13
+        vcvtph2psx %ymm1, %zmm15
+        vmulps    {rn-sae}, %zmm8, %zmm15, %zmm9
+
+/* reduced argument for exp2() computation */
+        vreduceps $9, {sae}, %zmm13, %zmm3
+        vmovdqu16 640+__svml_hpow_data_internal(%rip), %zmm8
+        vreduceps $9, {sae}, %zmm9, %zmm2
+
+/* y*log2(x) in FP16 */
+        vcvtps2phx {rd-sae}, %zmm9, %ymm11
+
+/* reduced argument in FP16 format */
+        vcvtps2phx %zmm2, %ymm9
+        vcvtps2phx %zmm3, %ymm4
+        vcvtps2phx {rd-sae}, %zmm13, %ymm15
+        vinsertf32x8 $1, %ymm4, %zmm9, %zmm7
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm5, %zmm7, %zmm10
+        vfmadd213ph {rn-sae}, %zmm6, %zmm7, %zmm10
+        vfmadd213ph {rn-sae}, %zmm8, %zmm7, %zmm10
+        vinsertf32x8 $1, %ymm15, %zmm11, %zmm11
+
+/* Poly*2^floor(xe) */
+        vscalefph {rn-sae}, %zmm11, %zmm10, %zmm2
+
+/* Go to special inputs processing branch */
+        jne       .LBL_SPECIAL_VALUES_BRANCH
+                                # LOE rbx r12 r13 r14 r15 edx zmm0 zmm1 zmm2
+
+/* Restore registers
+ * and exit the function
+ */
+
+.LBL_EXIT:
+        vmovaps   %zmm2, %zmm0
+        movq      %rbp, %rsp
+        popq      %rbp
+        .cfi_def_cfa 7, 8
+        .cfi_restore 6
+        ret
+        .cfi_def_cfa 6, 16
+        .cfi_offset 6, -16
+
+/* Branch to process
+ * special inputs
+ */
+
+.LBL_SPECIAL_VALUES_BRANCH:
+        vmovups   %zmm0, 64(%rsp)
+        vmovups   %zmm1, 128(%rsp)
+        vmovups   %zmm2, 192(%rsp)
+                                # LOE rbx r12 r13 r14 r15 edx zmm2
+
+        xorl      %eax, %eax
+        movq      %r12, 16(%rsp)
+        /*  DW_CFA_expression: r12 (r12) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -240; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0c, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x10, 0xff, 0xff, 0xff, 0x22
+        movl      %eax, %r12d
+        movq      %r13, 8(%rsp)
+        /*  DW_CFA_expression: r13 (r13) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -248; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0d, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x08, 0xff, 0xff, 0xff, 0x22
+        movl      %edx, %r13d
+        movq      %r14, (%rsp)
+        /*  DW_CFA_expression: r14 (r14) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -256; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0e, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x00, 0xff, 0xff, 0xff, 0x22
+                                # LOE rbx r15 r12d r13d
+
+/* Range mask
+ * bits check
+ */
+
+.LBL_RANGEMASK_CHECK:
+        btl       %r12d, %r13d
+
+/* Call scalar math function */
+        jc        .LBL_SCALAR_MATH_CALL
+                                # LOE rbx r15 r12d r13d
+
+/* Special inputs
+ * processing loop
+ */
+
+.LBL_SPECIAL_VALUES_LOOP:
+        incl      %r12d
+        cmpl      $32, %r12d
+
+/* Check bits in range mask */
+        jl        .LBL_RANGEMASK_CHECK
+                                # LOE rbx r15 r12d r13d
+
+        movq      16(%rsp), %r12
+        .cfi_restore 12
+        movq      8(%rsp), %r13
+        .cfi_restore 13
+        movq      (%rsp), %r14
+        .cfi_restore 14
+        vmovups   192(%rsp), %zmm2
+
+/* Go to exit */
+        jmp       .LBL_EXIT
+        /*  DW_CFA_expression: r12 (r12) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -240; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0c, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x10, 0xff, 0xff, 0xff, 0x22
+        /*  DW_CFA_expression: r13 (r13) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -248; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0d, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x08, 0xff, 0xff, 0xff, 0x22
+        /*  DW_CFA_expression: r14 (r14) (DW_OP_lit8; DW_OP_minus; DW_OP_const4s: -64; DW_OP_and; DW_OP_const4s: -256; DW_OP_plus)  */
+        .cfi_escape 0x10, 0x0e, 0x0e, 0x38, 0x1c, 0x0d, 0xc0, 0xff, 0xff, 0xff, 0x1a, 0x0d, 0x00, 0xff, 0xff, 0xff, 0x22
+                                # LOE rbx r12 r13 r14 r15 zmm2
+
+/* Scalar math fucntion call
+ * to process special input
+ */
+
+.LBL_SCALAR_MATH_CALL:
+        movl      %r12d, %r14d
+        vmovsh    64(%rsp,%r14,2), %xmm1
+        vmovsh    128(%rsp,%r14,2), %xmm2
+        vcvtsh2ss %xmm1, %xmm1, %xmm0
+        vcvtsh2ss %xmm2, %xmm2, %xmm1
+        vzeroupper
+        call      powf@PLT
+                                # LOE rbx r14 r15 r12d r13d xmm0
+
+        vmovaps   %xmm0, %xmm1
+        vxorps    %xmm0, %xmm0, %xmm0
+        vmovss    %xmm1, %xmm0, %xmm2
+        vcvtss2sh %xmm2, %xmm2, %xmm3
+        vmovsh    %xmm3, 192(%rsp,%r14,2)
+
+/* Process special inputs in loop */
+        jmp       .LBL_SPECIAL_VALUES_LOOP
+                                # LOE rbx r15 r12d r13d
+        .cfi_endproc
+
+        .type	__svml_pows32,@function
+        .size	__svml_pows32,.-__svml_pows32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hpow_data_internal:
+	.rept	16
+        .long	0x3f800000
+	.endr
+	.rept	16
+        .long	0xbe1ffcac
+	.endr
+	.rept	16
+        .long	0x3e9864bc
+	.endr
+	.rept	16
+        .long	0xbebd2851
+	.endr
+	.rept	16
+        .long	0x3ef64dc7
+	.endr
+	.rept	16
+        .long	0xbf389e6d
+	.endr
+	.rept	16
+        .long	0x3fb8aa2c
+	.endr
+	.rept	32
+        .word	0x2d12
+	.endr
+	.rept	32
+        .word	0x332e
+	.endr
+	.rept	32
+        .word	0x3992
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+        .type	__svml_hpow_data_internal,@object
+        .size	__svml_hpow_data_internal,704

--- a/linux/avx512/svml_z0_sin_h_la.s
+++ b/linux/avx512/svml_z0_sin_h_la.s
@@ -1,0 +1,215 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *  Computing 2^(-5)*(RShifter0 + x*(1/pi));
+ *  The scaling needed to get around limited exponent range for long Pi representation.
+ *  fN0 = (int)(sX/pi)*(2^(-5))
+ *  Argument reduction:  x + N*(nPi1+nPi2), where nPi1+nPi2 ~ -pi
+ *  The sign bit, will treat hY as integer value to look at last bit
+ *  Then compute polynomial: hR + hR3*fPoly
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_sins32
+
+__svml_sins32:
+
+        .cfi_startproc
+
+/*
+ * We actually compute 2^(-5)*(RShifter0 + x*(1/pi));
+ * scaling needed to get around limited exponent range for long Pi representation
+ */
+        vmovdqu16 192+__svml_hsin_data_internal(%rip), %zmm5
+        vmovdqu16 128+__svml_hsin_data_internal(%rip), %zmm1
+
+/* Argument reduction:  x + N*(nPi1+nPi2), where nPi1+nPi2 ~ -pi */
+        vmovdqu16 256+__svml_hsin_data_internal(%rip), %zmm4
+        vmovdqu16 320+__svml_hsin_data_internal(%rip), %zmm2
+
+/* (hR2*c3 + c2) */
+        vmovdqu16 384+__svml_hsin_data_internal(%rip), %zmm7
+        vmovdqu16 448+__svml_hsin_data_internal(%rip), %zmm9
+
+/*
+ * Variables:
+ * H
+ * S
+ * HM
+ * No callout
+ * Copy argument
+ * Needed to set sin(-0)=-0
+ */
+        vpandd    __svml_hsin_data_internal(%rip), %zmm0, %zmm13
+        vfmadd213ph {rn-sae}, %zmm1, %zmm13, %zmm5
+
+/* |sX| > threshold? */
+        vpcmpgtw  64+__svml_hsin_data_internal(%rip), %zmm13, %k1
+
+/* fN0 = (int)(sX/pi)*(2^(-5)) */
+        vsubph    {rn-sae}, %zmm1, %zmm5, %zmm10
+
+/*
+ * sign bit, will treat hY as integer value to look at last bit
+ * shift to FP16 sign position
+ */
+        vpsllw    $15, %zmm5, %zmm6
+        vfmadd213ph {rn-sae}, %zmm13, %zmm10, %zmm4
+        vfmadd213ph {rn-sae}, %zmm4, %zmm2, %zmm10
+
+/* hR*hR */
+        vmulph    {rn-sae}, %zmm10, %zmm10, %zmm8
+        vfmadd231ph {rn-sae}, %zmm8, %zmm7, %zmm9
+        vmulph    {rn-sae}, %zmm10, %zmm8, %zmm11
+
+/* hR + hR3*fPoly */
+        vfmadd213ph {rn-sae}, %zmm10, %zmm9, %zmm11
+
+/* short path */
+        kortestd  %k1, %k1
+        vpxord    %zmm13, %zmm0, %zmm3
+
+/* add in input sign */
+        vpxord    %zmm3, %zmm6, %zmm12
+
+/* add sign bit to result (logical XOR between fPoly and isgn bits) */
+        vpxord    %zmm12, %zmm11, %zmm0
+
+/* Go to exit */
+        jne       .LBL_EXIT
+                                # LOE rbx rbp r12 r13 r14 r15 zmm0 zmm3 zmm13 k1
+
+        ret
+
+/* Restore registers
+ * and exit the function
+ */
+
+.LBL_EXIT:
+        vmovups   512+__svml_hsin_data_internal(%rip), %zmm6
+
+/* RShifter + x*(1/pi) will round to RShifter+N, where N=(int)(x/pi) */
+        vmovups   576+__svml_hsin_data_internal(%rip), %zmm5
+
+/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi */
+        vmovups   640+__svml_hsin_data_internal(%rip), %zmm7
+        vmovups   704+__svml_hsin_data_internal(%rip), %zmm9
+        vmovups   832+__svml_hsin_data_internal(%rip), %zmm12
+        vmovaps   %zmm6, %zmm11
+
+/* convert to FP32 */
+        vextractf32x8 $1, %zmm13, %ymm4
+        vcvtph2psx %ymm13, %zmm8
+        vcvtph2psx %ymm4, %zmm10
+        vfmadd231ps {rn-sae}, %zmm8, %zmm5, %zmm11
+        vfmadd213ps {rn-sae}, %zmm6, %zmm10, %zmm5
+
+/* c2*sR2 + c1 */
+        vmovups   768+__svml_hsin_data_internal(%rip), %zmm4
+
+/* sN = (int)(x/pi) = sY - Rshifter */
+        vsubps    {rn-sae}, %zmm6, %zmm11, %zmm2
+        vsubps    {rn-sae}, %zmm6, %zmm5, %zmm1
+
+/* sign bit, will treat sY as integer value to look at last bit */
+        vpslld    $31, %zmm11, %zmm6
+        vfmadd231ps {rn-sae}, %zmm2, %zmm7, %zmm8
+        vfmadd231ps {rn-sae}, %zmm1, %zmm7, %zmm10
+        vpslld    $31, %zmm5, %zmm7
+        vfmadd213ps {rn-sae}, %zmm8, %zmm9, %zmm2
+        vfmadd213ps {rn-sae}, %zmm10, %zmm9, %zmm1
+
+/* sR*sR */
+        vmulps    {rn-sae}, %zmm2, %zmm2, %zmm14
+        vmulps    {rn-sae}, %zmm1, %zmm1, %zmm15
+        vmovaps   %zmm4, %zmm5
+        vfmadd231ps {rn-sae}, %zmm14, %zmm12, %zmm5
+        vfmadd231ps {rn-sae}, %zmm15, %zmm12, %zmm4
+
+/* sR2*sR */
+        vmulps    {rn-sae}, %zmm2, %zmm14, %zmm12
+        vmulps    {rn-sae}, %zmm1, %zmm15, %zmm14
+
+/* sR + sR3*sPoly */
+        vfmadd213ps {rn-sae}, %zmm2, %zmm5, %zmm12
+        vfmadd213ps {rn-sae}, %zmm1, %zmm4, %zmm14
+
+/* add sign bit to result (logical XOR between sPoly and i32_sgn bits) */
+        vxorps    %zmm6, %zmm12, %zmm1
+        vxorps    %zmm7, %zmm14, %zmm8
+        vcvtps2phx %zmm1, %ymm2
+        vcvtps2phx %zmm8, %ymm9
+        vinsertf32x8 $1, %ymm9, %zmm2, %zmm10
+
+/* needed to set sin(-0)=-0 */
+        vpxord    %zmm3, %zmm10, %zmm3
+
+/*
+ * ensure results are always exactly the same for common arguments
+ * (return fast path result for common args)
+ */
+        vpblendmw %zmm3, %zmm0, %zmm0{%k1}
+        ret
+                                # LOE rbx rbp r12 r13 r14 r15 zmm0
+        .cfi_endproc
+
+        .type	__svml_sins32,@function
+        .size	__svml_sins32,.-__svml_sins32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hsin_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x52ac
+	.endr
+	.rept	32
+        .word	0x5200
+	.endr
+	.rept	32
+        .word	0x2118
+	.endr
+	.rept	32
+        .word	0xd648
+	.endr
+	.rept	32
+        .word	0xa7ed
+	.endr
+	.rept	32
+        .word	0x2007
+	.endr
+	.rept	32
+        .word	0xb155
+	.endr
+	.rept	16
+        .long	0x4b400000
+	.endr
+	.rept	16
+        .long	0x3ea2f983
+	.endr
+	.rept	16
+        .long	0xc0490fdb
+	.endr
+	.rept	16
+        .long	0x33bbbd2e
+	.endr
+	.rept	16
+        .long	0xbe2a026e
+	.endr
+	.rept	16
+        .long	0x3bf9f9b6
+	.endr
+        .type	__svml_hsin_data_internal,@object
+        .size	__svml_hsin_data_internal,896

--- a/linux/avx512/svml_z0_sin_h_la.s
+++ b/linux/avx512/svml_z0_sin_h_la.s
@@ -24,21 +24,45 @@
 __svml_sins32:
 
         .cfi_startproc
-
-/*
- * We actually compute 2^(-5)*(RShifter0 + x*(1/pi));
- * scaling needed to get around limited exponent range for long Pi representation
- */
-        vmovdqu16 192+__svml_hsin_data_internal(%rip), %zmm5
+        kxnord  %k7, %k7, %k7
+        vmovdqu16 __svml_hsin_data_internal(%rip), %zmm25
+        vmovdqu16 64+__svml_hsin_data_internal(%rip), %zmm24
         vmovdqu16 128+__svml_hsin_data_internal(%rip), %zmm1
-
-/* Argument reduction:  x + N*(nPi1+nPi2), where nPi1+nPi2 ~ -pi */
-        vmovdqu16 256+__svml_hsin_data_internal(%rip), %zmm4
-        vmovdqu16 320+__svml_hsin_data_internal(%rip), %zmm2
-
-/* (hR2*c3 + c2) */
+        vmovdqu16 192+__svml_hsin_data_internal(%rip), %zmm23
+        vmovdqu16 256+__svml_hsin_data_internal(%rip), %zmm22
+        vmovdqu16 320+__svml_hsin_data_internal(%rip), %zmm29
         vmovdqu16 384+__svml_hsin_data_internal(%rip), %zmm7
-        vmovdqu16 448+__svml_hsin_data_internal(%rip), %zmm9
+        vmovdqu16 448+__svml_hsin_data_internal(%rip), %zmm21
+        vmovdqu16   512+__svml_hsin_data_internal(%rip), %zmm20
+        vmovdqu16   576+__svml_hsin_data_internal(%rip), %zmm16
+        vmovdqu16   640+__svml_hsin_data_internal(%rip), %zmm28
+        vmovdqu16   704+__svml_hsin_data_internal(%rip), %zmm26
+        vmovdqu16   832+__svml_hsin_data_internal(%rip), %zmm18
+
+/* npy_half* in -> %rdi, npy_half* out -> %rsi, size_t N -> %rdx */
+.looparray__sin_h:
+        cmpq    $31, %rdx
+        ja .loaddata__sin_h
+/* set up mask %k7 for masked load instruction */
+        movl    $1, %eax
+        movl    %edx, %ecx
+        sall    %cl, %eax
+        subl    $1, %eax
+        kmovd   %eax, %k7
+/* Constant required for masked load */
+        movl    $15360, %eax
+        vpbroadcastw    %eax, %zmm0
+        vmovdqu16 (%rdi), %zmm0{%k7}
+        jmp .funcbegin_sin_h
+.loaddata__sin_h:
+        vmovdqu16 (%rdi), %zmm0
+        addq $64, %rdi
+        
+.funcbegin_sin_h:
+
+        vmovdqu16 %zmm23, %zmm5
+        vmovdqu16 %zmm22, %zmm4
+        vmovdqu16 %zmm21, %zmm9
 
 /*
  * Variables:
@@ -49,11 +73,11 @@ __svml_sins32:
  * Copy argument
  * Needed to set sin(-0)=-0
  */
-        vpandd    __svml_hsin_data_internal(%rip), %zmm0, %zmm13
+        vpandd %zmm25, %zmm0, %zmm13
         vfmadd213ph {rn-sae}, %zmm1, %zmm13, %zmm5
 
 /* |sX| > threshold? */
-        vpcmpgtw  64+__svml_hsin_data_internal(%rip), %zmm13, %k1
+        vpcmpgtw %zmm24, %zmm13, %k1
 
 /* fN0 = (int)(sX/pi)*(2^(-5)) */
         vsubph    {rn-sae}, %zmm1, %zmm5, %zmm10
@@ -64,7 +88,7 @@ __svml_sins32:
  */
         vpsllw    $15, %zmm5, %zmm6
         vfmadd213ph {rn-sae}, %zmm13, %zmm10, %zmm4
-        vfmadd213ph {rn-sae}, %zmm4, %zmm2, %zmm10
+        vfmadd213ph {rn-sae}, %zmm4, %zmm29, %zmm10
 
 /* hR*hR */
         vmulph    {rn-sae}, %zmm10, %zmm10, %zmm8
@@ -86,6 +110,13 @@ __svml_sins32:
 
 /* Go to exit */
         jne       .LBL_EXIT
+
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray__sin_h
                                 # LOE rbx rbp r12 r13 r14 r15 zmm0 zmm3 zmm13 k1
 
         ret
@@ -95,60 +126,53 @@ __svml_sins32:
  */
 
 .LBL_EXIT:
-        vmovups   512+__svml_hsin_data_internal(%rip), %zmm6
 
-/* RShifter + x*(1/pi) will round to RShifter+N, where N=(int)(x/pi) */
-        vmovups   576+__svml_hsin_data_internal(%rip), %zmm5
-
-/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi */
-        vmovups   640+__svml_hsin_data_internal(%rip), %zmm7
-        vmovups   704+__svml_hsin_data_internal(%rip), %zmm9
-        vmovups   832+__svml_hsin_data_internal(%rip), %zmm12
-        vmovaps   %zmm6, %zmm11
+        vmovdqu16   %zmm16, %zmm5
+        vmovaps   %zmm20, %zmm11
 
 /* convert to FP32 */
         vextractf32x8 $1, %zmm13, %ymm4
         vcvtph2psx %ymm13, %zmm8
         vcvtph2psx %ymm4, %zmm10
         vfmadd231ps {rn-sae}, %zmm8, %zmm5, %zmm11
-        vfmadd213ps {rn-sae}, %zmm6, %zmm10, %zmm5
+        vfmadd213ps {rn-sae}, %zmm20, %zmm10, %zmm5
 
 /* c2*sR2 + c1 */
-        vmovups   768+__svml_hsin_data_internal(%rip), %zmm4
+        vmovdqu16   768+__svml_hsin_data_internal(%rip), %zmm4
 
 /* sN = (int)(x/pi) = sY - Rshifter */
-        vsubps    {rn-sae}, %zmm6, %zmm11, %zmm2
-        vsubps    {rn-sae}, %zmm6, %zmm5, %zmm1
+        vsubps    {rn-sae}, %zmm20, %zmm11, %zmm30
+        vsubps    {rn-sae}, %zmm20, %zmm5, %zmm31
 
 /* sign bit, will treat sY as integer value to look at last bit */
-        vpslld    $31, %zmm11, %zmm6
-        vfmadd231ps {rn-sae}, %zmm2, %zmm7, %zmm8
-        vfmadd231ps {rn-sae}, %zmm1, %zmm7, %zmm10
-        vpslld    $31, %zmm5, %zmm7
-        vfmadd213ps {rn-sae}, %zmm8, %zmm9, %zmm2
-        vfmadd213ps {rn-sae}, %zmm10, %zmm9, %zmm1
+        vpslld    $31, %zmm11, %zmm19
+        vfmadd231ps {rn-sae}, %zmm30, %zmm28, %zmm8
+        vfmadd231ps {rn-sae}, %zmm31, %zmm28, %zmm10
+        vpslld    $31, %zmm5, %zmm27
+        vfmadd213ps {rn-sae}, %zmm8, %zmm26, %zmm30
+        vfmadd213ps {rn-sae}, %zmm10, %zmm26, %zmm31
 
 /* sR*sR */
-        vmulps    {rn-sae}, %zmm2, %zmm2, %zmm14
-        vmulps    {rn-sae}, %zmm1, %zmm1, %zmm15
+        vmulps    {rn-sae}, %zmm30, %zmm30, %zmm14
+        vmulps    {rn-sae}, %zmm31, %zmm31, %zmm15
         vmovaps   %zmm4, %zmm5
-        vfmadd231ps {rn-sae}, %zmm14, %zmm12, %zmm5
-        vfmadd231ps {rn-sae}, %zmm15, %zmm12, %zmm4
+        vfmadd231ps {rn-sae}, %zmm14, %zmm18, %zmm5
+        vfmadd231ps {rn-sae}, %zmm15, %zmm18, %zmm4
 
 /* sR2*sR */
-        vmulps    {rn-sae}, %zmm2, %zmm14, %zmm12
-        vmulps    {rn-sae}, %zmm1, %zmm15, %zmm14
+        vmulps    {rn-sae}, %zmm30, %zmm14, %zmm17
+        vmulps    {rn-sae}, %zmm31, %zmm15, %zmm14
 
 /* sR + sR3*sPoly */
-        vfmadd213ps {rn-sae}, %zmm2, %zmm5, %zmm12
-        vfmadd213ps {rn-sae}, %zmm1, %zmm4, %zmm14
+        vfmadd213ps {rn-sae}, %zmm30, %zmm5, %zmm17
+        vfmadd213ps {rn-sae}, %zmm31, %zmm4, %zmm14
 
 /* add sign bit to result (logical XOR between sPoly and i32_sgn bits) */
-        vxorps    %zmm6, %zmm12, %zmm1
-        vxorps    %zmm7, %zmm14, %zmm8
-        vcvtps2phx %zmm1, %ymm2
+        vxorps    %zmm19, %zmm17, %zmm31
+        vxorps    %zmm27, %zmm14, %zmm8
+        vcvtps2phx %zmm31, %ymm30
         vcvtps2phx %zmm8, %ymm9
-        vinsertf32x8 $1, %ymm9, %zmm2, %zmm10
+        vinsertf32x8 $1, %ymm9, %zmm30, %zmm10
 
 /* needed to set sin(-0)=-0 */
         vpxord    %zmm3, %zmm10, %zmm3
@@ -158,6 +182,13 @@ __svml_sins32:
  * (return fast path result for common args)
  */
         vpblendmw %zmm3, %zmm0, %zmm0{%k1}
+
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray__sin_h
         ret
                                 # LOE rbx rbp r12 r13 r14 r15 zmm0
         .cfi_endproc

--- a/linux/avx512/svml_z0_sin_h_la.s
+++ b/linux/avx512/svml_z0_sin_h_la.s
@@ -244,3 +244,4 @@ __svml_hsin_data_internal:
 	.endr
         .type	__svml_hsin_data_internal,@object
         .size	__svml_hsin_data_internal,896
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_sin_h_la.s
+++ b/linux/avx512/svml_z0_sin_h_la.s
@@ -50,7 +50,7 @@ __svml_sins32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_sin_h

--- a/linux/avx512/svml_z0_sinh_h_la.s
+++ b/linux/avx512/svml_z0_sinh_h_la.s
@@ -1,0 +1,143 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Compute sinh(x) as (exp(x)-exp(-x))/2,
+ *   where exp is calculated as
+ *   exp(M*ln2 + ln2*(j/2^k) + r) = 2^M * 2^(j/2^k) * exp(r)
+ *
+ *   Special cases:
+ *
+ *   sinh(NaN) = quiet NaN, and raise invalid exception
+ *   sinh(INF) = that INF
+ *   sinh(x)   = x for subnormals
+ *   sinh(x) overflows for big x and returns MAXLOG+log(2)
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_sinhs32
+
+__svml_sinhs32:
+
+        .cfi_startproc
+
+/* Shifter + x*log2(e) */
+        vmovdqu16 64+__svml_hsinh_data_internal(%rip), %zmm2
+        vmovdqu16 128+__svml_hsinh_data_internal(%rip), %zmm3
+
+/* Argument reduction:  x - N*log(2) */
+        vmovdqu16 192+__svml_hsinh_data_internal(%rip), %zmm4
+        vmovdqu16 576+__svml_hsinh_data_internal(%rip), %zmm11
+        vmovdqu16 256+__svml_hsinh_data_internal(%rip), %zmm5
+        vmovdqu16 384+__svml_hsinh_data_internal(%rip), %zmm8
+        vmovdqu16 448+__svml_hsinh_data_internal(%rip), %zmm7
+        vmovdqu16 512+__svml_hsinh_data_internal(%rip), %zmm9
+        vpandd    __svml_hsinh_data_internal(%rip), %zmm0, %zmm6
+        vfmadd213ph {rz-sae}, %zmm3, %zmm6, %zmm2
+        vsubph    {rn-sae}, %zmm3, %zmm2, %zmm10
+
+/* hN - 1 */
+        vsubph    {rn-sae}, %zmm11, %zmm10, %zmm12
+
+/* save sign */
+        vpxord    %zmm0, %zmm6, %zmm1
+        vfnmadd231ph {rn-sae}, %zmm10, %zmm4, %zmm6
+
+/* 2^(hN-1) */
+        vscalefph {rn-sae}, %zmm12, %zmm11, %zmm4
+        vfnmadd231ph {rn-sae}, %zmm10, %zmm5, %zmm6
+
+/* fixup for Inf results */
+        vfpclassph $8, %zmm4, %k1
+
+/* 2^(-hN)*2 */
+        vrcpph    %zmm4, %zmm3
+
+/* exp(R) -1 */
+        vmovaps   %zmm7, %zmm0
+        vpandd    320+__svml_hsinh_data_internal(%rip), %zmm6, %zmm13
+
+/* exp(-R) -1 */
+        vfnmadd231ph {rn-sae}, %zmm13, %zmm8, %zmm7
+        vfmadd231ph {rn-sae}, %zmm13, %zmm8, %zmm0
+
+/* 2^(-hN)*R */
+        vmulph    {rn-sae}, %zmm13, %zmm3, %zmm14
+
+/* 2^hN*R */
+        vmulph    {rn-sae}, %zmm13, %zmm4, %zmm2
+        vfnmadd213ph {rn-sae}, %zmm9, %zmm13, %zmm7
+        vfmadd213ph {rn-sae}, %zmm9, %zmm13, %zmm0
+        vfnmadd213ph {rn-sae}, %zmm11, %zmm13, %zmm7
+        vfmadd213ph {rn-sae}, %zmm11, %zmm13, %zmm0
+
+/* T - Tm*0.25 */
+        vmovdqu16 640+__svml_hsinh_data_internal(%rip), %zmm13
+
+/* -Tm*mpoly*0.25 */
+        vmulph    {rn-sae}, %zmm14, %zmm7, %zmm15
+        vfnmadd213ph {rn-sae}, %zmm4, %zmm13, %zmm3
+        vmulph    {rn-sae}, %zmm13, %zmm15, %zmm7
+
+/* T*poly - Tm*mpoly */
+        vfmadd213ph {rn-sae}, %zmm7, %zmm2, %zmm0
+        vaddph    {rn-sae}, %zmm3, %zmm0, %zmm0
+
+/* fixup */
+        vmovdqu16 %zmm4, %zmm0{%k1}
+
+/* fix sign */
+        vpxord    %zmm1, %zmm0, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_sinhs32,@function
+        .size	__svml_sinhs32,.-__svml_sinhs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_hsinh_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x3dc5
+	.endr
+	.rept	32
+        .word	0x6600
+	.endr
+	.rept	32
+        .word	0x398c
+	.endr
+	.rept	32
+        .word	0x8af4
+	.endr
+	.rept	32
+        .word	0xbfff
+	.endr
+	.rept	32
+        .word	0x2976
+	.endr
+	.rept	32
+        .word	0x3176
+	.endr
+	.rept	32
+        .word	0x37ff
+	.endr
+	.rept	32
+        .word	0x3c00
+	.endr
+	.rept	32
+        .word	0x3400
+	.endr
+        .type	__svml_hsinh_data_internal,@object
+        .size	__svml_hsinh_data_internal,704

--- a/linux/avx512/svml_z0_sinh_h_la.s
+++ b/linux/avx512/svml_z0_sinh_h_la.s
@@ -169,3 +169,4 @@ __svml_hsinh_data_internal:
 	.endr
         .type	__svml_hsinh_data_internal,@object
         .size	__svml_hsinh_data_internal,704
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_sinh_h_la.s
+++ b/linux/avx512/svml_z0_sinh_h_la.s
@@ -51,7 +51,7 @@ __svml_sinhs32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_sinh_h

--- a/linux/avx512/svml_z0_tan_h_la.s
+++ b/linux/avx512/svml_z0_tan_h_la.s
@@ -24,15 +24,39 @@
 __svml_tans32:
 
         .cfi_startproc
-
+        kxnord  %k7, %k7, %k7
+        vmovups   __svml_htan_data_internal(%rip), %zmm25
         vmovups   64+__svml_htan_data_internal(%rip), %zmm4
-
-/* RShifter + x*(2/pi) will round to RShifter+N, where N=(int)(x/pi) */
-        vmovups   128+__svml_htan_data_internal(%rip), %zmm3
-
-/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi/2 */
+        vmovups   128+__svml_htan_data_internal(%rip), %zmm29
         vmovups   192+__svml_htan_data_internal(%rip), %zmm5
         vmovups   256+__svml_htan_data_internal(%rip), %zmm7
+        vmovdqu16 320+__svml_htan_data_internal(%rip), %zmm30
+        vmovdqu16 384+__svml_htan_data_internal(%rip), %zmm23
+        vmovdqu16 448+__svml_htan_data_internal(%rip), %zmm31
+        vmovdqu16 512+__svml_htan_data_internal(%rip), %zmm26
+
+/* npy_half* in -> %rdi, npy_half* out -> %rsi, size_t N -> %rdx */
+.looparray__tan_h:
+        cmpq    $31, %rdx
+        ja .loaddata__tan_h
+/* set up mask %k7 for masked load instruction */
+        movl    $1, %eax
+        movl    %edx, %ecx
+        sall    %cl, %eax
+        subl    $1, %eax
+        kmovd   %eax, %k7
+/* Constant required for masked load */
+        movl    $15360, %eax
+        vpbroadcastw    %eax, %zmm0
+        vmovdqu16 (%rdi), %zmm0{%k7}
+        jmp .funcbegin_tan_h
+.loaddata__tan_h:
+        vmovdqu16 (%rdi), %zmm0
+        addq $64, %rdi
+        
+.funcbegin_tan_h:
+
+        vmovups   %zmm29, %zmm3
         vmovaps   %zmm4, %zmm9
 
 /*
@@ -40,7 +64,7 @@ __svml_tans32:
  * Copy argument
  * Needed to set sin(-0)=-0
  */
-        vpandd    __svml_htan_data_internal(%rip), %zmm0, %zmm1
+        vpandd    %zmm25, %zmm0, %zmm1
         vpxord    %zmm1, %zmm0, %zmm0
 
 /* convert to FP32 */
@@ -61,12 +85,9 @@ __svml_tans32:
         vfmadd231ps {rn-sae}, %zmm12, %zmm5, %zmm8
 
 /* polynomial ~ tan(R)/R */
-        vmovdqu16 320+__svml_htan_data_internal(%rip), %zmm3
-        vmovdqu16 384+__svml_htan_data_internal(%rip), %zmm9
-        vmovdqu16 448+__svml_htan_data_internal(%rip), %zmm4
+        vmovdqu16 %zmm23, %zmm9
         vfmadd213ps {rn-sae}, %zmm6, %zmm7, %zmm10
         vfmadd213ps {rn-sae}, %zmm8, %zmm7, %zmm12
-        vmovdqu16 512+__svml_htan_data_internal(%rip), %zmm6
         vcvtps2phx %zmm10, %ymm11
         vcvtps2phx %zmm12, %ymm13
         vcvtps2phx %zmm14, %ymm15
@@ -74,22 +95,29 @@ __svml_tans32:
         vinsertf32x8 $1, %ymm13, %zmm11, %zmm2
 
 /* hR*hR */
-        vmulph    {rn-sae}, %zmm2, %zmm2, %zmm5
-        vfmadd231ph {rn-sae}, %zmm5, %zmm3, %zmm9
-        vfmadd213ph {rn-sae}, %zmm4, %zmm5, %zmm9
-        vfmadd213ph {rn-sae}, %zmm6, %zmm5, %zmm9
+        vmulph    {rn-sae}, %zmm2, %zmm2, %zmm28
+        vfmadd231ph {rn-sae}, %zmm28, %zmm30, %zmm9
+        vfmadd213ph {rn-sae}, %zmm31, %zmm28, %zmm9
+        vfmadd213ph {rn-sae}, %zmm26, %zmm28, %zmm9
         vinsertf32x8 $1, %ymm14, %zmm15, %zmm8
 
 /* result = 1/tan(R) when hN = (int)(x/(Pi/2)) is odd */
         vpmovw2m  %zmm8, %k1
 
 /* add sign to hR */
-        vpxord    %zmm8, %zmm2, %zmm7
-        vfmadd213ph {rn-sae}, %zmm7, %zmm7, %zmm9
+        vpxord    %zmm8, %zmm2, %zmm27
+        vfmadd213ph {rn-sae}, %zmm27, %zmm27, %zmm9
         vrcpph    %zmm9, %zmm9{%k1}
 
 /* needed to set sin(-0)=-0 */
         vpxord    %zmm0, %zmm9, %zmm0
+
+/* store result to our array and adjust pointers */
+        vmovdqu16 %zmm0, (%rsi){%k7}
+        addq $64, %rsi
+        subq $32, %rdx
+        cmpq $0, %rdx
+        jg .looparray__tan_h
         ret
 
         .cfi_endproc

--- a/linux/avx512/svml_z0_tan_h_la.s
+++ b/linux/avx512/svml_z0_tan_h_la.s
@@ -46,7 +46,7 @@ __svml_tans32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_tan_h

--- a/linux/avx512/svml_z0_tan_h_la.s
+++ b/linux/avx512/svml_z0_tan_h_la.s
@@ -1,0 +1,132 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   Implementation reduces argument as:
+ *   sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi/2
+ *   RShifter + x*(2/pi) will round to RShifter+N, where N=(int)(x/pi)
+ *   To get sign bit we treat sY as integer value to look at last bit
+ *   Compute polynomial ~ tan(R)/R
+ *   Result = 1/tan(R) when sN = (int)(x/(Pi/2)) is odd
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_tans32
+
+__svml_tans32:
+
+        .cfi_startproc
+
+        vmovups   64+__svml_htan_data_internal(%rip), %zmm4
+
+/* RShifter + x*(2/pi) will round to RShifter+N, where N=(int)(x/pi) */
+        vmovups   128+__svml_htan_data_internal(%rip), %zmm3
+
+/* Argument reduction:  sX + N*(sNPi1+sNPi2), where sNPi1+sNPi2 ~ -pi/2 */
+        vmovups   192+__svml_htan_data_internal(%rip), %zmm5
+        vmovups   256+__svml_htan_data_internal(%rip), %zmm7
+        vmovaps   %zmm4, %zmm9
+
+/*
+ * No callout
+ * Copy argument
+ * Needed to set sin(-0)=-0
+ */
+        vpandd    __svml_htan_data_internal(%rip), %zmm0, %zmm1
+        vpxord    %zmm1, %zmm0, %zmm0
+
+/* convert to FP32 */
+        vextractf32x8 $1, %zmm1, %ymm2
+        vcvtph2psx %ymm1, %zmm6
+        vcvtph2psx %ymm2, %zmm8
+        vfmadd231ps {rn-sae}, %zmm6, %zmm3, %zmm9
+        vfmadd213ps {rn-sae}, %zmm4, %zmm8, %zmm3
+
+/* sN = (int)(x/pi) = sY - Rshifter */
+        vsubps    {rn-sae}, %zmm4, %zmm9, %zmm10
+        vsubps    {rn-sae}, %zmm4, %zmm3, %zmm12
+
+/* sign bit, will treat sY as integer value to look at last bit */
+        vpslld    $31, %zmm9, %zmm14
+        vpslld    $31, %zmm3, %zmm1
+        vfmadd231ps {rn-sae}, %zmm10, %zmm5, %zmm6
+        vfmadd231ps {rn-sae}, %zmm12, %zmm5, %zmm8
+
+/* polynomial ~ tan(R)/R */
+        vmovdqu16 320+__svml_htan_data_internal(%rip), %zmm3
+        vmovdqu16 384+__svml_htan_data_internal(%rip), %zmm9
+        vmovdqu16 448+__svml_htan_data_internal(%rip), %zmm4
+        vfmadd213ps {rn-sae}, %zmm6, %zmm7, %zmm10
+        vfmadd213ps {rn-sae}, %zmm8, %zmm7, %zmm12
+        vmovdqu16 512+__svml_htan_data_internal(%rip), %zmm6
+        vcvtps2phx %zmm10, %ymm11
+        vcvtps2phx %zmm12, %ymm13
+        vcvtps2phx %zmm14, %ymm15
+        vcvtps2phx %zmm1, %ymm14
+        vinsertf32x8 $1, %ymm13, %zmm11, %zmm2
+
+/* hR*hR */
+        vmulph    {rn-sae}, %zmm2, %zmm2, %zmm5
+        vfmadd231ph {rn-sae}, %zmm5, %zmm3, %zmm9
+        vfmadd213ph {rn-sae}, %zmm4, %zmm5, %zmm9
+        vfmadd213ph {rn-sae}, %zmm6, %zmm5, %zmm9
+        vinsertf32x8 $1, %ymm14, %zmm15, %zmm8
+
+/* result = 1/tan(R) when hN = (int)(x/(Pi/2)) is odd */
+        vpmovw2m  %zmm8, %k1
+
+/* add sign to hR */
+        vpxord    %zmm8, %zmm2, %zmm7
+        vfmadd213ph {rn-sae}, %zmm7, %zmm7, %zmm9
+        vrcpph    %zmm9, %zmm9{%k1}
+
+/* needed to set sin(-0)=-0 */
+        vpxord    %zmm0, %zmm9, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_tans32,@function
+        .size	__svml_tans32,.-__svml_tans32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_htan_data_internal:
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	16
+        .long	0x4b000000
+	.endr
+	.rept	16
+        .long	0x3f22f983
+	.endr
+	.rept	16
+        .long	0xbfc90fdb
+	.endr
+	.rept	16
+        .long	0x333bbd2e
+	.endr
+	.rept	32
+        .word	0x2e06
+	.endr
+	.rept	32
+        .word	0x2f6c
+	.endr
+	.rept	32
+        .word	0x355f
+	.endr
+	.rept	32
+        .word	0x82e5
+	.endr
+        .type	__svml_htan_data_internal,@object
+        .size	__svml_htan_data_internal,576

--- a/linux/avx512/svml_z0_tan_h_la.s
+++ b/linux/avx512/svml_z0_tan_h_la.s
@@ -158,3 +158,4 @@ __svml_htan_data_internal:
 	.endr
         .type	__svml_htan_data_internal,@object
         .size	__svml_htan_data_internal,576
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_tanh_h_la.s
+++ b/linux/avx512/svml_z0_tanh_h_la.s
@@ -180,3 +180,4 @@ __svml_htanh_data_internal:
 	.endr
         .type	__svml_htanh_data_internal,@object
         .size	__svml_htanh_data_internal,320
+	 .section        .note.GNU-stack,"",@progbits

--- a/linux/avx512/svml_z0_tanh_h_la.s
+++ b/linux/avx512/svml_z0_tanh_h_la.s
@@ -1,0 +1,154 @@
+/*******************************************
+* Copyright (C) 2022 Intel Corporation
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************/
+
+/*
+ * ALGORITHM DESCRIPTION:
+ *
+ *   NOTE: Since the hyperbolic tangent function is odd
+ *         (tanh(x) = -tanh(-x)), below algorithm deals with the absolute
+ *         value of the argument |x|: tanh(x) = sign(x) * tanh(|x|)
+ *
+ *   Get absolute value of argument xa = |x| and sign(x)
+ *   Limit arguments by threshold xa = min(xa, Thres), Thres<4.0
+ *   Get table index as Shifter + xa, RZ mode
+ *   Lookup polynomial coefficients: c1, c2 with the index
+ *   Compute polynomial and add sign x back: x+x*Poly
+ *
+ *   IEEE SPECIAL CONDITIONS:
+ *   x = [+,-]0, r = [+,-]0
+ *   x = +Inf,   r = +1
+ *   x = -Inf,   r = -1
+ *   x = QNaN,   r = QNaN
+ *   x = SNaN,   r = QNaN
+ *
+ *
+ */
+
+        .text
+
+        .align    16,0x90
+        .globl __svml_tanhs32
+
+__svml_tanhs32:
+
+        .cfi_startproc
+
+/* xa = min(xa, Thres), Thres<4.0 */
+        vmovdqu16 192+__svml_htanh_data_internal(%rip), %zmm1
+
+/* get table index */
+        vmovdqu16 256+__svml_htanh_data_internal(%rip), %zmm3
+
+/*
+ * No callout
+ * xa = |x|
+ */
+        vpandd    128+__svml_htanh_data_internal(%rip), %zmm0, %zmm2
+        vminph    {sae}, %zmm2, %zmm1, %zmm6
+
+/* Shifter + xa, RZ mode */
+        vaddph    {rz-sae}, %zmm3, %zmm6, %zmm4
+
+/* look up poly coefficients: c1, c2 */
+        vpermw    __svml_htanh_data_internal(%rip), %zmm4, %zmm5
+
+/* sign(x) */
+        vpxord    %zmm0, %zmm2, %zmm7
+        vpermw    64+__svml_htanh_data_internal(%rip), %zmm4, %zmm0
+
+/* polynomial */
+        vfmadd213ph {rn-sae}, %zmm5, %zmm6, %zmm0
+
+/* add sign back to x */
+        vpxord    %zmm7, %zmm6, %zmm8
+
+/* x+x*Poly */
+        vfmadd213ph {rn-sae}, %zmm8, %zmm8, %zmm0
+        ret
+
+        .cfi_endproc
+
+        .type	__svml_tanhs32,@function
+        .size	__svml_tanhs32,.-__svml_tanhs32
+
+        .section .rodata, "a"
+        .align 64
+
+__svml_htanh_data_internal:
+        .word	0x0c00
+        .word	0x216a
+        .word	0x273e
+        .word	0x2a6c
+        .word	0x2c9c
+        .word	0x2dc3
+        .word	0x2e7c
+        .word	0x2eb1
+        .word	0x2e5a
+        .word	0x2d82
+        .word	0x2c3a
+        .word	0x2932
+        .word	0x21b4
+        .word	0xa561
+        .word	0xab02
+        .word	0xadb5
+        .word	0xafe8
+        .word	0xb109
+        .word	0xb216
+        .word	0xb319
+        .word	0xb408
+        .word	0xb47e
+        .word	0xb4ee
+        .word	0xb558
+        .word	0xb5bc
+        .word	0xb61a
+        .word	0xb673
+        .word	0xb6c6
+        .word	0xb715
+        .word	0xb75f
+        .word	0xb7a5
+        .word	0xb7e7
+        .word	0xa94d
+        .word	0xafc2
+        .word	0xb228
+        .word	0xb404
+        .word	0xb4b8
+        .word	0xb52f
+        .word	0xb56d
+        .word	0xb57d
+        .word	0xb567
+        .word	0xb537
+        .word	0xb4f6
+        .word	0xb4aa
+        .word	0xb45a
+        .word	0xb409
+        .word	0xb373
+        .word	0xb2dd
+        .word	0xb250
+        .word	0xb1ce
+        .word	0xb156
+        .word	0xb0e9
+        .word	0xb086
+        .word	0xb02c
+        .word	0xafb6
+        .word	0xaf22
+        .word	0xae9d
+        .word	0xae25
+        .word	0xadb7
+        .word	0xad54
+        .word	0xacfa
+        .word	0xaca9
+        .word	0xac5e
+        .word	0xac1a
+	.rept	32
+        .word	0x7fff
+	.endr
+	.rept	32
+        .word	0x42e3
+	.endr
+	.rept	32
+        .word	0x5a00
+	.endr
+        .type	__svml_htanh_data_internal,@object
+        .size	__svml_htanh_data_internal,320

--- a/linux/avx512/svml_z0_tanh_h_la.s
+++ b/linux/avx512/svml_z0_tanh_h_la.s
@@ -52,7 +52,7 @@ __svml_tanhs32:
         subl    $1, %eax
         kmovd   %eax, %k7
 /* Constant required for masked load */
-        movl    $15360, %eax
+        movl    $0, %eax
         vpbroadcastw    %eax, %zmm0
         vmovdqu16 (%rdi), %zmm0{%k7}
         jmp .funcbegin_tanh_h


### PR DESCRIPTION
Open sourcing new content for FP16 umath functions based on AVX-512 FP16 ISA on Intel Sapphire Rapids. These were measured to be **140x faster** than the scalar counterpart in NumPy (which required conversion to FP32 and back). These have max ULP error of 3.05 (detailed ULP error listed here: https://github.com/numpy/numpy/pull/23351#issue-1612155219). 

|FP16 Ufunc|scalar FP16 (ms)|AVX512 FP16 SVML (μs) |Speed up on AVX-512 FP16 SPR|
|-|-|-|-|
|arctanh|8.58|31.5|272.4|
|tanh|7.38|27.1|272.3|
|cbrt|6.76|30.5|221.6|
|arcsinh|8.05|43.7|184.2|
|arctan|5.18|29.2|177.4|
|arccosh|7.41|48.2|153.7|
|arccos|4.94|33.3|148.3|
|cosh|5.02|34.2|146.8|
|arcsin|4.39|31.6|138.9|
|sinh|7.22|54.8|131.8|
|log10|4.11|31.7|129.7|
|sin|3.43|29.1|117.9|
|log1p|5.1|43.3|117.8|
|cos|3.38|32.2|105.0|
|log|2.63|29.8|88.3|
|tan|5.78|68.9|83.9|
|log2|2.31|30.3|76.2|
|expm1|4.89|65.0|75.2|
|exp|2.14|28.9|74.0|
|exp2|2.08|28.8|72.2|
