### PR TITLE
Set invalid flag if there are +/- INF for sin/cos

### DIFF
--- a/linux/avx512/svml_z0_cos_h_la.s
+++ b/linux/avx512/svml_z0_cos_h_la.s
@@ -71,8 +71,13 @@ __svml_coss32:
 .loaddata__cos_h:
         vmovdqu16 (%rdi), %zmm0
         addq $64, %rdi
-        
+
 .funcbegin_cos_h:
+
+/* Check for +/- INF */
+        vfpclassph $24, %zmm0, %k6
+/* Dummy vsubph instruction to raise an invalid */
+        vsubph  %zmm0, %zmm0, %zmm8{%k6}{z}
 
         vmovdqu16 %zmm22, %zmm8
         vmovdqu16 %zmm21, %zmm15

--- a/linux/avx512/svml_z0_sin_h_la.s
+++ b/linux/avx512/svml_z0_sin_h_la.s
@@ -57,8 +57,13 @@ __svml_sins32:
 .loaddata__sin_h:
         vmovdqu16 (%rdi), %zmm0
         addq $64, %rdi
-        
+
 .funcbegin_sin_h:
+
+/* Check for +/- INF */
+        vfpclassph $24, %zmm0, %k6
+/* Dummy vsubph instruction to raise an invalid */
+        vsubph  %zmm0, %zmm0, %zmm9{%k6}{z}
 
         vmovdqu16 %zmm23, %zmm5
         vmovdqu16 %zmm22, %zmm4


### PR DESCRIPTION
AVX-512FP16 sin/cos need to raise invalid if the array contains +/- INF